### PR TITLE
Fix skip logic for integration tests

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -6,7 +6,7 @@ ign_get_sources(tests)
 # FIXME the mesh test does not work
 list(REMOVE_ITEM tests mesh.cc)
 
-if (SKIP_av)
+if (SKIP_av OR INTERNAL_SKIP_av)
   list(REMOVE_ITEM tests encoder_timing.cc)
   list(REMOVE_ITEM tests video_encoder.cc)
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes build failure reported in #263 when dependencies for `av` component are not available.

## Summary

Since https://github.com/ignitionrobotics/ign-cmake/pull/165, we need to check both the `SKIP_av` and `INTERNAL_SKIP_av` before building integration tests that require the `av` component. Otherwise the integration tests fail to build, as reported in #263.

~~~
/build/source/test/integration/video_encoder.cc:21:10: fatal error: ignition/common/VideoEncoder.hh: No such file or directory
   21 | #include "ignition/common/VideoEncoder.hh"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
~~~

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
