### PR TITLE
Fix segfault when destroying Event objects

### DIFF
--- a/events/include/gz/common/Event.hh
+++ b/events/include/gz/common/Event.hh
@@ -29,6 +29,7 @@
 #include <gz/common/config.hh>
 #include <gz/common/events/Export.hh>
 #include <gz/common/events/Types.hh>
+#include <gz/utils/SuppressWarning.hh>
 
 namespace gz
 {
@@ -98,7 +99,7 @@ namespace gz
         /// destruction of an Event.
         public: std::weak_ptr<Connection> publicConnection;
       };
-
+IGN_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \def EvtConnectionMap
       /// \brief Event Connection map typedef.
       protected: typedef std::map<int, std::unique_ptr<EventConnection>>
@@ -113,6 +114,7 @@ namespace gz
       /// \brief List of connections to remove
       private: std::list<typename EvtConnectionMap::const_iterator>
               connectionsToRemove;
+IGN_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
     };
 
     /// \brief A class that encapsulates a connection.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -5,6 +5,10 @@ if (SKIP_av OR INTERNAL_SKIP_av)
   list(REMOVE_ITEM tests video_encoder.cc)
 endif()
 
+if (WIN32)
+  list(REMOVE_ITEM tests events_with_plugins.cc)
+endif()
+
 ign_build_tests(
   TYPE INTEGRATION
   SOURCES ${tests}
@@ -28,4 +32,11 @@ endif()
 
 if(TARGET INTEGRATION_video_encoder)
   target_link_libraries(INTEGRATION_video_encoder ${PROJECT_LIBRARY_TARGET_NAME}-av)
+endif()
+
+if(TARGET INTEGRATION_events_with_plugins)
+  target_link_libraries(INTEGRATION_events_with_plugins ${PROJECT_LIBRARY_TARGET_NAME}-events dl)
+  add_dependencies(INTEGRATION_events_with_plugins EventEmitterPlugin)
+  target_compile_definitions(INTEGRATION_events_with_plugins  PRIVATE
+    "EventEmitterPlugin_LIB=\"$<TARGET_FILE:EventEmitterPlugin>\"")
 endif()

--- a/test/integration/events_with_plugins.cc
+++ b/test/integration/events_with_plugins.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+// dlfcn is safe to include since this test does not run on windows (see
+// CMakeLists.txt)
+#include <dlfcn.h>
+#include <gz/common/Event.hh>
+#include <gz/utils/ExtraTestMacros.hh>
+
+#include "plugins/EventEmitterPlugin.hh"
+
+using namespace gz;
+
+TEST(EventWithPluginsTest, EventDestruction)
+{
+  // EventEmitterPlugin_LIB is defined in the CMake
+  void *handle = dlopen(EventEmitterPlugin_LIB, RTLD_LAZY | RTLD_LOCAL);
+  auto createEvent =
+      reinterpret_cast<common::Event *(*)()>(dlsym(handle, "createEvent"));
+  {
+    // We use a unique_ptr instead of a raw delete call to avoid a compiler 
+    // warning that `common::Event` does not have a virtual destructor.
+    std::unique_ptr<common::Event> event;
+    event.reset(createEvent());
+    // This dynamic_cast is important to replicate how event's are signaled in
+    // downstream applications
+    auto *eventTyped = dynamic_cast<TestEvent *>(event.get());
+    ASSERT_NE(nullptr, eventTyped);
+    eventTyped->Signal();
+
+    dlclose(handle);
+  }
+  SUCCEED();
+}

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -8,12 +8,14 @@ add_library(IGNBadPluginSize          SHARED BadPluginSize.cc)
 target_link_libraries(IGNBadPluginSize PRIVATE ${PROJECT_LIBRARY_TARGET_NAME})
 add_library(GzDummyPlugins           SHARED DummyPlugins.cc)
 target_link_libraries(GzDummyPlugins PRIVATE ${PROJECT_LIBRARY_TARGET_NAME})
+add_library(EventEmitterPlugin           SHARED EventEmitterPlugin.cc)
 
 set_property(TARGET IGNBadPluginAlign PROPERTY CXX_STANDARD 11)
 set_property(TARGET IGNBadPluginAPIVersionNew PROPERTY CXX_STANDARD 11)
 set_property(TARGET IGNBadPluginAPIVersionOld PROPERTY CXX_STANDARD 11)
 set_property(TARGET IGNBadPluginSize PROPERTY CXX_STANDARD 11)
 set_property(TARGET GzDummyPlugins PROPERTY CXX_STANDARD 11)
+set_property(TARGET EventEmitterPlugin PROPERTY CXX_STANDARD 17)
 
 # Create a variable for the name of the header which will contain the dummy plugin path.
 # This variable gets put in the cache so that it is available at generation time.
@@ -47,3 +49,8 @@ else()
       VERBATIM)
 endif()
 add_dependencies(GzDummyPlugins GzDummyPluginsPathHeader)
+
+
+if (NOT SKIP_event)
+  target_link_libraries(EventEmitterPlugin ${PROJECT_LIBRARY_TARGET_NAME}-events)
+endif()

--- a/test/plugins/EventEmitterPlugin.cc
+++ b/test/plugins/EventEmitterPlugin.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+#include <gz/common/Event.hh>
+#include "EventEmitterPlugin.hh"
+
+using namespace gz;
+
+extern "C" {
+common::Event *createEvent()
+{
+  return new TestEvent;
+}
+}

--- a/test/plugins/EventEmitterPlugin.hh
+++ b/test/plugins/EventEmitterPlugin.hh
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef EVENTEMITTERPLUGIN_HH_
+#define EVENTEMITTERPLUGIN_HH_
+
+#include <gz/common/Event.hh>
+#include <gz/common/events/Export.hh>
+
+using TestEvent =
+    gz::common::EventT<void(), class TestEventTag>;
+#endif 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The segfault is caused when attempting to polymorphically destroy an `EventT` object that was instantiated inside a plugin (or any shared library loaded via dlopen) and the plugin has since been unloaded. Since `EventT` is a template, it's destructor is instantated in the translation unit that is part of the plugin and when that plugin is unloaded, the destructor is removed from memory as well. Gazebo stores pointers of the base class `Event`  (not `EventT`) in a container. Since the destructor of `Event` is virtual, the system will try to call the destructor of `EventT` when destroying that container, but that function is no longer available.

The solution is to ensure the destructor of `EventT` is never called. In this PR, this is accomplished by making `Event`'s destructor non-virtual and moving all data members to the base class. I believe it's safe to not call `EventT`s destructor as long as the destructor is trivial and `EventT` has no data members, but I would appreciate any feedback if this is not the case. 

Note, this will not fix the issue if an application stores `EventT` objects (instead of `Event` objects) instantiated by plugins and the plugins get unloaded. 

To test, run `ign gazebo shapes.sdf` and exit using `ctrl-c`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.