### PR TITLE
Fix race condition in FileLogger

### DIFF
--- a/include/ignition/common/Console.hh
+++ b/include/ignition/common/Console.hh
@@ -113,13 +113,25 @@ namespace ignition
                    /// \brief Destructor.
                    public: virtual ~Buffer();
 
+                   /// \brief Writes _count characters to the string buffer
+                   /// \param[in] _char Input rharacter array.
+                   /// \param[in] _count Number of characters in array.
+                   /// \return The number of characters successfully written.
+                   public: std::streamsize xsputn(
+                        const char *_char, std::streamsize _count) override;
+
                    /// \brief Sync the stream (output the string buffer
                    /// contents).
                    /// \return Return 0 on success.
-                   public: virtual int sync();
+                   public: int sync() override;
 
                    /// \brief Stream to output information into.
                    public: std::ofstream *stream;
+                   /// \brief Mutex to synchronize writes to the string buffer
+                   /// and the output stream.
+                   /// \todo(nkoenig) Put this back in for ign-common5, and
+                   /// remove the corresponding static version.
+                   // public: std::mutex syncMutex;
                  };
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -363,15 +363,31 @@ FileLogger::Buffer::~Buffer()
 }
 
 /////////////////////////////////////////////////
+std::streamsize FileLogger::Buffer::xsputn(const char *_char,
+                                           std::streamsize _count)
+{
+  auto lk = BufferLock(reinterpret_cast<std::uintptr_t>(this));
+  return std::stringbuf::xsputn(_char, _count);
+}
+
+/////////////////////////////////////////////////
 int FileLogger::Buffer::sync()
 {
   if (!this->stream)
     return -1;
 
-  *this->stream << this->str();
+  {
+    auto lk = BufferLock(reinterpret_cast<std::uintptr_t>(this));
+    *this->stream << this->str();
+  }
 
-  this->stream->flush();
-
-  this->str("");
+  {
+    auto lk = BufferLock(reinterpret_cast<std::uintptr_t>(this));
+    this->stream->flush();
+  }
+  {
+    auto lk = BufferLock(reinterpret_cast<std::uintptr_t>(this));
+    this->str("");
+  }
   return !(*this->stream);
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Some of the flaky tests in gz-sim are still caused by race conditions in `Console`, this time in the `FileLogger`.
This PR applies the same fix from #227 to `Console::FileLogger`. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
