### PR TITLE
Fix FindSharedLibrary for relative plugin paths

### DIFF
--- a/src/SystemPaths.cc
+++ b/src/SystemPaths.cc
@@ -160,8 +160,9 @@ const std::list<std::string> &SystemPaths::PluginPaths()
 /////////////////////////////////////////////////
 std::string SystemPaths::FindSharedLibrary(const std::string &_libName)
 {
+  URIPath libname(_libName);
   // Short circuit if the given library name is an absolute path to a file.
-  if (exists(_libName))
+  if (libname.IsAbsolute() && exists(_libName))
     return _libName;
 
   // Trigger loading paths from env


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

If you are running gazebo in the same folder that a custom plugin is located, then you are able to find it. According with the comment I think this code is more appropriate.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
