### PR TITLE
Support absolute Windows paths with forward slashes in common::FindFile

### DIFF
--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -359,6 +359,21 @@ TEST_F(SystemPathsFixture, FindFile)
     EXPECT_EQ("", sp.FindFile(uriBadDir));
   }
 
+  // Windows path with only one forward slash
+#ifdef _WIN32
+  const auto tmpDirForwardSlash = "C:/Windows";
+  const auto homeDirForwardSlash = "C:/Users";
+  const auto badDirForwardSlash = "C:/bad";
+  {
+    // We do not expect equality as  sp.FindFile could normalize the
+    // path and return a different string
+    // The behaviour tested here is just that C:/Windows, C:/Users are found
+    EXPECT_NE("", sp.FindFile(tmpDirForwardSlash));
+    EXPECT_NE("", sp.FindFile(homeDirForwardSlash));
+    EXPECT_EQ("", sp.FindFile(badDirForwardSlash));
+  }
+#endif
+
   // Custom callback
   {
     auto tmpCb = [tmpDir](const std::string &_s)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

While working on https://github.com/gazebosim/gz-sim/pull/1574, some tests were failing with error:
~~~
    Start 43: UNIT_ign_TEST

43: Test command: C:\src\ign-gazebo\build\bin\UNIT_ign_TEST.exe "--gtest_output=xml:C:/src/ign-gazebo/build/test_results/UNIT_ign_TEST.xml"
43: Environment variables:
43:  IGN_CONFIG_PATH=C:/src/ign-gazebo/build/test/conf
43:  IGN_GAZEBO_SYSTEM_PLUGIN_PATH=C:/src/ign-gazebo/build/bin
43: Test timeout computed to be: 240
43: Running main() from C:\src\ign-gazebo\test\gtest\src\gtest_main.cc
43: [==========] Running 3 tests from 1 test suite.
43: [----------] Global test environment set-up.
43: [----------] 3 tests from CmdLine
43: [ RUN      ] CmdLine.Server
43: Running command [ C:/Users/STraversaro/AppData/Local/mambaforge/envs/igngaz/Library/bin/ign gazebo -s  -r -v 4 --iterations 5 C:/src/ign-gazebo/test/worlds/plugins.sdf]
43: C:\src\ign-gazebo\src\ign_TEST.cc(73): error: Expected: (output.find("iteration " + std::to_string(i))) != (std::string::npos), actual: 18446744073709551615 vs 18446744073709551615
43: [Msg] Ignition Gazebo Server v6.10.0
43: [Err] [D:\bld\libignition-common4_1656525324646\work\src\SystemPaths.cc:379] Unable to find file with URI [C:///src/ign-gazebo/test/worlds/plugins.sdf]
43: [Err] [D:\bld\libignition-common4_1656525324646\work\src\SystemPaths.cc:469] Could not resolve file [C:/src/ign-gazebo/test/worlds/plugins.sdf]
43: [Err] [C:\src\ign-gazebo\src\Server.cc:109] Failed to find world [C:/src/ign-gazebo/test/worlds/plugins.sdf]
~~~

Apparently what was happening is that the `C:/src/ign-gazebo/test/worlds/plugins.sdf` path was interpreted as an URI, resulting in the strange error on `C:///src/ign-gazebo/test/worlds/plugins.sdf` . While technical `C:/` could be an URI with the one-letter scheme `C`, in practice I am not aware of any one letter URI scheme, and on the other hand many Windows programs supports both absolute paths with backslash and forward slashes, see for example Python:
~~~
(igngaz) C:\src\ign-gazebo\build>type hello.py
print("Hello world")

(igngaz) C:\src\ign-gazebo\build>python C:\src\ign-gazebo\build\hello.py
Hello world

(igngaz) C:\src\ign-gazebo\build>python C:/src/ign-gazebo/build/hello.py
Hello world
~~~

To support this use case, this PR modifies the `common::FindFile` function to first check if a file that starts with `C:/`  or similar is an existing absolute file in the system. If such a file does not exist, then the search procedure falls back to consider it an URI.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.