### PR TITLE
Add code coverage ignore file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(ignition-common3 VERSION 3.14.1)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 2.8.0 REQUIRED COMPONENTS utilities)
+find_package(ignition-cmake2 2.14.0 REQUIRED COMPONENTS utilities)
 set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 
 #============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ message(STATUS "-------------------------------------------\n")
 #============================================================================
 configure_file("${PROJECT_SOURCE_DIR}/cppcheck.suppress.in"
                ${PROJECT_BINARY_DIR}/cppcheck.suppress)
+configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
+               ${PROJECT_BINARY_DIR}/coverage.ignore)
 
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS av events graphics profiler)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,6 @@ message(STATUS "-------------------------------------------\n")
 #============================================================================
 configure_file("${PROJECT_SOURCE_DIR}/cppcheck.suppress.in"
                ${PROJECT_BINARY_DIR}/cppcheck.suppress)
-configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
-               ${PROJECT_BINARY_DIR}/coverage.ignore)
 
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS av events graphics profiler)

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,3 +1,12 @@
 profiler/src/Remotery/lib/*
 profiler/src/Remotery/vis/*
 graphics/src/tiny_obj_loader.h
+av/include/ignition/common/HWVideo.hh
+av/include/ignition/common/HWEncoder.hh
+av/src/HWEncoder.cc
+include/ignition/common/FlagSet.hh
+src/FilesystemBoost.cc
+src/win_dirent.h
+examples/assert_example.cc
+graphics/src/tinyxml2/tinyxml2.h
+graphics/src/tinyxml2/tinyxml2.cpp

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,0 +1,3 @@
+profiler/src/Remotery/lib/*
+profiler/src/Remotery/vis/*
+graphics/src/tiny_obj_loader.h

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,12 +1,4 @@
-profiler/src/Remotery/lib/*
-profiler/src/Remotery/vis/*
+profiler/src/Remotery/*
 graphics/src/tiny_obj_loader.h
-av/include/ignition/common/HWVideo.hh
-av/include/ignition/common/HWEncoder.hh
-av/src/HWEncoder.cc
-include/ignition/common/FlagSet.hh
-src/FilesystemBoost.cc
 src/win_dirent.h
-examples/assert_example.cc
-graphics/src/tinyxml2/tinyxml2.h
-graphics/src/tinyxml2/tinyxml2.cpp
+graphics/src/tinyxml2/*


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# New feature

Part of [gz-sim#1575](https://github.com/gazebosim/gz-sim/issues/1575)

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Add `coverage.ignore.in` to ignore vendor code in code coverage report. See [gz-cmake#279](https://github.com/gazebosim/gz-cmake/pull/279) for detail.

Ignore `profiler/src/Remotery` and `graphics/src/tiny_obj_loader.h`

Increase the coverage from ~74% -> ~79%

Before
![20220713151601](https://user-images.githubusercontent.com/50132891/178841020-a908e92c-4c58-42c6-9b3f-a65c682de976.png)

After
![20220713150911](https://user-images.githubusercontent.com/50132891/178841027-76b3172a-4e5a-4fa9-9f32-3b5434a63819.png)


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
