### PR TITLE
Remove deprecated include

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,11 +22,6 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
     gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER}
 )
 
-# This is required by the WorkerPool::WaitForResults(const Time &_timeout)
-# TODO(anyone): GZ_DEPRECATED(4). Remove this part when the method is removed
-target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE
-  ${gz-math${GZ_MATH_VER}_INCLUDE_DIRS})
-
 # Handle non-Windows configuration settings
 if(NOT WIN32)
   # Link the libraries that we don't expect to find on Windows


### PR DESCRIPTION
Follow up to

* https://github.com/gazebosim/gz-common/pull/90
* https://github.com/gazebosim/gz-common/pull/273

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Just a left-over that I found.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
