### PR TITLE
CI Configuration for new dependency in #402

### DIFF
--- a/.github/ci/dependencies.yaml
+++ b/.github/ci/dependencies.yaml
@@ -2,4 +2,9 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: hidmic/libcsv-cmake-module
+    version: ci_matching_branch/hidmic/csv-data
+  gz-math:
+    type: git
+    url: https://github.com/gazebosim/gz-math
+    version: ci_matching_branch/hidmic/csv-data
+

--- a/.github/ci/dependencies.yaml
+++ b/.github/ci/dependencies.yaml
@@ -1,0 +1,5 @@
+repositories:
+  gz-cmake:
+    type: git
+    url: https://github.com/gazebosim/gz-cmake
+    version: hidmic/libcsv-cmake-module


### PR DESCRIPTION
Testing CI for #402 

For actions, we override the `dependencies.yaml` to temporarily use the gz-cmake PR: https://github.com/gazebosim/gz-cmake/pull/290

For macOS, we add a dependency on `libcsv` in the homebrew formula with the same `ci_matching_branch` branch name: https://github.com/osrf/homebrew-simulation/pull/1976

Additionally for macOS, I duplicated the https://github.com/gazebosim/gz-cmake/pull/290 branch with the same `ci_matching_branch` branch name.

Signed-off-by: Michael Carroll <michael@openrobotics.org>