### PR TITLE
Fix deprecation warning from new ffmpeg

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -149,7 +149,7 @@ bool AudioDecoder::Decode(uint8_t **_outBuffer, unsigned int *_outBufferSize)
         // decodedFrame->linesize[0].
         int size = decodedFrame->nb_samples *
           av_get_bytes_per_sample(this->dataPtr->codecCtx->sample_fmt) *
-          this->dataPtr->codecCtx->channels;
+          this->dataPtr->codecCtx->ch_layout.nb_channels;
 
         // Resize the audio buffer as necessary
         if (*_outBufferSize + size > maxBufferSize)


### PR DESCRIPTION
Closes #415

This bit of code is already protected by LIBAVFORMAT_VERSION_MAJOR >= 59, which had the `ch_layout.nb_channels` that is recommended to be used by their API: https://github.com/FFmpeg/FFmpeg/blob/d931554f668186729bf290ed9afa6e9a4417328b/libavcodec/avcodec.h#L1009-L1016

Signed-off-by: Michael Carroll <michael@openrobotics.org>