### PR TITLE
Introduces Flips UV flag, removes empty space

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -579,8 +579,7 @@ SubMesh AssimpLoader::Implementation::CreateSubMesh(
       math::Vector3d texcoords;
       texcoords.X(_assimpMesh->mTextureCoords[uvIdx][vertexIdx].x);
       texcoords.Y(_assimpMesh->mTextureCoords[uvIdx][vertexIdx].y);
-      // TODO(luca) why do we need 1.0 - Y?
-      subMesh.AddTexCoordBySet(texcoords.X(), 1.0 - texcoords.Y(), uvIdx);
+      subMesh.AddTexCoordBySet(texcoords.X(), texcoords.Y(), uvIdx);
       ++uvIdx;
     }
   }
@@ -618,6 +617,7 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
       aiProcess_JoinIdenticalVertices |
       aiProcess_RemoveRedundantMaterials |
       aiProcess_SortByPType |
+      aiProcess_FlipUVs |
 #ifndef GZ_ASSIMP_PRE_5_2_0
       aiProcess_PopulateArmatureData |
 #endif

--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -111,7 +111,6 @@ MeshManager::MeshManager()
   this->dataPtr->fileExtensions.insert("gltf");
   this->dataPtr->fileExtensions.insert("glb");
   this->dataPtr->fileExtensions.insert("fbx");
-
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #393 

## Summary
This commit introduces the flip uv flag for unnessary y flip during addition of texture coordinates. Furthermore removes
an empty line.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

