### PR TITLE
Backport from 5 to 3 - Fix deprecation warning from new ffmpeg

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -156,8 +156,8 @@ bool AudioDecoder::Decode(uint8_t **_outBuffer, unsigned int *_outBufferSize)
         // decodedFrame->data[0], which is why we can't use
         // decodedFrame->linesize[0].
         int size = decodedFrame->nb_samples *
-          av_get_bytes_per_sample(this->dataPtr->codecCtx->sample_fmt) *
-          this->dataPtr->codecCtx->ch_layout.nb_channels;
+          av_get_bytes_per_sample(this->data->codecCtx->sample_fmt) *
+          this->data->codecCtx->ch_layout.nb_channels;
         // Resize the audio buffer as necessary
         if (*_outBufferSize + size > maxBufferSize)
         {

--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -156,9 +156,8 @@ bool AudioDecoder::Decode(uint8_t **_outBuffer, unsigned int *_outBufferSize)
         // decodedFrame->data[0], which is why we can't use
         // decodedFrame->linesize[0].
         int size = decodedFrame->nb_samples *
-          av_get_bytes_per_sample(this->data->codecCtx->sample_fmt) *
-          this->data->codecCtx->channels;
-
+          av_get_bytes_per_sample(this->dataPtr->codecCtx->sample_fmt) *
+          this->dataPtr->codecCtx->ch_layout.nb_channels;
         // Resize the audio buffer as necessary
         if (*_outBufferSize + size > maxBufferSize)
         {


### PR DESCRIPTION
# ➡️ Backport

Port gz-common5 to ign-common3

Backports: 
 * https://github.com/gazebosim/gz-common/pull/416

Branch comparison: https://github.com/gazebosim/gz-common/compare/ign-common3...Crola1702:Crola1702/5_to_3-2022_08_16

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)
