### PR TITLE
Fix ABI checker with testing module

### DIFF
--- a/testing/include/gz/common/testing/AutoLogFixture.hh
+++ b/testing/include/gz/common/testing/AutoLogFixture.hh
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2022 Open Source Robotics Foundation
+* Copyright (C) 2022 Open Source Robotics FoundationO
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 #ifndef GZ_COMMON_TESTING_AUTOLOGFIXTURE_HH_
 #define GZ_COMMON_TESTING_AUTOLOGFIXTURE_HH_
 
-#include <gtest/gtest.h>
+/// Protect to guarantee that gtest is included before this header.
+#ifdef GTEST_API_
 
 #include <memory>
 #include <string>
@@ -55,5 +56,9 @@ class AutoLogFixture : public ::testing::Test
 }  // namespace gz::common::testing
 
 #include <gz/common/testing/detail/AutoLogFixture.hh>
+
+#else
+#warning "AutoLogFixture needs <gtest/gtest.h> to be included in order to work"
+#endif  // GTEST_API_
 
 #endif  // GZ_COMMON_TESTING_AUTOLOGFIXTURE_HH_

--- a/testing/include/gz/common/testing/AutoLogFixture.hh
+++ b/testing/include/gz/common/testing/AutoLogFixture.hh
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2022 Open Source Robotics FoundationO
+* Copyright (C) 2022 Open Source Robotics Foundation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>

# 🦟 Bug fix

Fixes issue brought up in comment here: https://github.com/gazebosim/gz-common/pull/411#issuecomment-1220892591

## Summary

The header `AutoLogFixture.hh` is available to be used as part of a library or executable that links against `gtest`.  We don't want to introduce a hard dependency on `gtest` in `common::testing` for just this header, but it seems to annoy the ABI checker.

~~This adds a private include so that the gtest header may be resolved, even though downstream users of the `testing` component will never see it.~~

This puts the AutoLogFixture within a define guard `GTEST_API` to guarantee that gtest is available before using the autologfixture.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.