### PR TITLE
Skip CSV header when reading DataFrame

### DIFF
--- a/io/include/gz/common/DataFrame.hh
+++ b/io/include/gz/common/DataFrame.hh
@@ -179,7 +179,8 @@ namespace gz
         using FactoryT =
             math::InMemoryTimeVaryingVolumetricGridFactory<T, V>;
         std::vector<FactoryT> factories(dataColumnIndices.size());
-        for (auto it = _begin; it != _end; ++it)
+        auto it = _begin;
+        while (++it != _end)
         {
           const T time = IO<T>::ReadFrom(it->at(_timeColumnIndex));
           const math::Vector3<P> position{

--- a/io/include/gz/common/DataFrame.hh
+++ b/io/include/gz/common/DataFrame.hh
@@ -179,8 +179,7 @@ namespace gz
         using FactoryT =
             math::InMemoryTimeVaryingVolumetricGridFactory<T, V>;
         std::vector<FactoryT> factories(dataColumnIndices.size());
-        auto it = _begin;
-        while (++it != _end)
+        for (auto it = std::next(_begin); it != _end; ++it)
         {
           const T time = IO<T>::ReadFrom(it->at(_timeColumnIndex));
           const math::Vector3<P> position{

--- a/io/src/DataFrame_TEST.cc
+++ b/io/src/DataFrame_TEST.cc
@@ -52,10 +52,17 @@ TEST(DataFrameTests, SimpleCSV)
   ASSERT_TRUE(df.Has("temperature"));
   const DataT &temperatureData = df["temperature"];
   auto temperatureSession = temperatureData.StepTo(
-      temperatureData.CreateSession(), 0.5);
+      temperatureData.CreateSession(), 0.);
   ASSERT_TRUE(temperatureSession.has_value());
   const math::Vector3d position{5., 5., 0.};
   auto temperature = temperatureData.LookUp(
+      temperatureSession.value(), position);
+  ASSERT_TRUE(temperature.has_value());
+  EXPECT_DOUBLE_EQ(25.2, temperature.value());
+  temperatureSession = temperatureData.StepTo(
+      temperatureData.CreateSession(), 0.5);
+  ASSERT_TRUE(temperatureSession.has_value());
+  temperature = temperatureData.LookUp(
       temperatureSession.value(), position);
   ASSERT_TRUE(temperature.has_value());
   EXPECT_DOUBLE_EQ(25.1, temperature.value());


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-common/issues/434

## Summary

This patch fixes a minor issue introduced in #402. Namely, header row shouldn't be read in as numeric data. It also updates tests to identify this regression.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.