### PR TITLE
Add gdal to prerequisites

### DIFF
--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -81,6 +81,10 @@ The AV component requires:
   * [libavcodec](https://www.ffmpeg.org/libavcodec.html)
   * [libavutil](https://www.ffmpeg.org/libavutil.html)
 
+The Geospatial component requires:
+
+  * [gdal](https://gdal.org/)
+
 ### Windows
 
 First, follow the [gz-cmake](https://github.com/gazebosim/gz-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
@@ -94,7 +98,7 @@ conda activate gz-ws
 
 Install prerequisites:
 ```
-conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
+conda install freeimage gdal gts glib dlfcn-win32 ffmpeg --channel conda-forge
 ```
 
 Install Gazebo dependencies:


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

From source installation of common5 on Windows according to the tutorial fails to build the geospatial component.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.