### PR TITLE
3.15.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-common3 VERSION 3.14.2)
+project(ignition-common3 VERSION 3.15.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo Common 3.x
 
+## Gazebo Common 3.15.0 (2022-10-06)
+
+1. ign -> gz Migrate Ignition Headers
+    * [Pull request #418](https://github.com/gazebosim/gz-common/pull/418)
+
 ## Gazebo Common 3.14.2 (2022-08-16)
 
 1. Fix deprecation warning from new `ffmpeg`


### PR DESCRIPTION
# 🎈 Release

Preparation for 3.15.- release.

Comparison to 3.14.2: [https://github.com/gazebosim/<REPO>/compare/<LATEST_TAG_BRANCH>...<RELEASE_BRANCH>](https://github.com/gazebosim/gz-common/compare/ignition-common3_3.14.2...ign-common3)

Needed by https://github.com/gazebosim/gz-fuel-tools/pull/285

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.