### PR TITLE
Don't install CMakeLists.txt

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -1,7 +1,0 @@
-
-add_subdirectory(src)
-
-install(
-  DIRECTORY include/
-  DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL})
-

--- a/profiler/include/gz/CMakeLists.txt
+++ b/profiler/include/gz/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(common)

--- a/profiler/include/gz/common/CMakeLists.txt
+++ b/profiler/include/gz/common/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+ign_install_all_headers(COMPONENT profiler)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes unstable 3.15.0 debbuild issue

## Summary

Many of the 3.15.0 debbuilds were unstable:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-common3-debbuilder&build=1053)](https://build.osrfoundation.org/job/ign-common3-debbuilder/1053/) https://build.osrfoundation.org/job/ign-common3-debbuilder/1053/

~~~
dh_missing: warning: usr/include/ignition/common3/CMakeLists.txt exists in debian/tmp but is not installed to anywhere
~~~

The `profiler` component was installing its `CMakeLists.txt` file, probably due to an issue with #418. This changes the `CMakeLists.txt` pattern to match the `events` component.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
