### PR TITLE
Fix arm builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.2.0)
+project(gz-common5 VERSION 5.2.1)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================
@@ -18,7 +18,7 @@ set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/io/src/CSVStreams.cc
+++ b/io/src/CSVStreams.cc
@@ -43,7 +43,7 @@ std::istream &ExtractCSVToken(
   char character;
   if (_stream.peek(), !_stream.fail() && _stream.eof())
   {
-    _token = {CSVToken::TERMINATOR, EOF};
+    _token = {CSVToken::TERMINATOR, static_cast<char>(EOF)};
   }
   else if (_stream.get(character))
   {
@@ -121,7 +121,8 @@ std::istream &ParseCSVRow(
             state = FIELD_START;
             break;
           case CSVToken::TERMINATOR:
-            if (token.character != EOF || !_row.empty() || text.tellp() > 0)
+            if (token.character != static_cast<char>(EOF) || !_row.empty() ||
+                text.tellp() > 0)
             {
               _row.push_back(text.str());
               state = RECORD_END;
@@ -140,7 +141,8 @@ std::istream &ParseCSVRow(
           state = FIELD_END;
           break;
         }
-        if (token.type != CSVToken::TERMINATOR || token.character != EOF)
+        if (token.type != CSVToken::TERMINATOR ||
+            token.character != static_cast<char>(EOF))
         {
           text << token.character;
           break;


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

ARM doesn't allow narrowing conversions inside `{}` initializers. See here: https://build.osrfoundation.org/job/gz-common5-debbuilder/786/consoleFull#3015109326ea37b8d-a6d4-40ae-8431-d90c018842af

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.