### PR TITLE
5.2.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 ## Gazebo Common 5.x
 
+## Gazebo Common 5.2.1 (2022-10-19)
+
+1. Fix arm builds and tests
+    * [Pull request #462](https://github.com/gazebosim/gz-common/pull/462)
+    * [Pull request #463](https://github.com/gazebosim/gz-common/pull/463)
+
 ## Gazebo Common 5.2.0 (2022-10-18)
 
 1. Add CSV data parsing


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 5.2.1 release. This should fix the arm builds. Test done here: https://build.osrfoundation.org/job/gz-common5-debbuilder/797/

Comparison to 5.2.0: https://github.com/gazebosim/gz-common/compare/gz-common5_5.2.0...gz-common5

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.