### PR TITLE
Fix Capsule mesh generation

### DIFF
--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -975,11 +975,10 @@ void MeshManager::CreateCapsule(const std::string &_name,
       x = -sin(u * (IGN_PI * 2.0));
       y = cos(u * (IGN_PI * 2.0));
 
-      math::Vector3d p(
-      x * _radius * w, y, -z * _radius * w);
+      math::Vector3d p(x * _radius * w, y * _radius * w, z);
       // Compute vertex
       subMesh.AddVertex(math::Vector3d(
-        p + math::Vector3d(0.0, 0.5 * _length, 0.0)));
+        p + math::Vector3d(0.0, 0.0, 0.5 * _length)));
       subMesh.AddTexCoord({u, v * oneThird});
       subMesh.AddNormal(p.Normalize());
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1769

## Summary

In #186 Capsule was updated to be z-up, however when merging forward the ign-gz changes, the logic was accidentally reverted.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
