### PR TITLE
Prepare for 5.3.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.2.2)
+project(gz-common5 VERSION 5.3.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo Common 5.x
 
+## Gazebo Common 5.3.0 (2022-11-14)
+
+1. Expose Vertex & Index raw ptrs for efficient reading
+    * [Pull request #474](https://github.com/gazebosim/ign-common/pull/474)
+
 ## Gazebo Common 5.2.2 (2022-10-26)
 
 1. [Backport] Avoid Io.hh header name clash (#471) 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>


# 🎈 Release

Preparation for 5.3.0 release.

Comparison to 5.2.2: https://github.com/gazebosim/gz-common/compare/gz-common5_5.2.2...prepare_5.3.0

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-rendering/pull/752

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
