### PR TITLE
Fixed animation with wierd animation due bad times

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -689,6 +689,11 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
         // Compute the position into a math pose
         auto& posKey = animChan->mPositionKeys[keyIdx];
         auto& quatKey = animChan->mRotationKeys[keyIdx];
+        if ((keyIdx != 0) &&
+            (std::abs(animChan->mRotationKeys[keyIdx - 1].mTime - quatKey.mTime) < 1.0))
+        {
+          continue;
+        }
         math::Vector3d pos(posKey.mValue.x, posKey.mValue.y, posKey.mValue.z);
         math::Quaterniond quat(quatKey.mValue.w, quatKey.mValue.x,
             quatKey.mValue.y, quatKey.mValue.z);


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Sometimes the assimp rotation value returns a invalid `mTime`. This lines should check this

wrong behaviour
![curtains_bad](https://user-images.githubusercontent.com/1933907/201992696-351cea1e-ea82-44e2-9cb4-74d14243ae38.gif)

Fixed
![curtains](https://user-images.githubusercontent.com/1933907/201992713-c6638b32-0d68-44c1-9d6c-9984eff4dad4.gif)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
