### PR TITLE
Fix out of bounds access to rotation array in assimp loader

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -683,12 +683,19 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
     {
       auto& animChan = anim->mChannels[chanIdx];
       auto chanName = ToString(animChan->mNodeName);
-      for (unsigned keyIdx = 0; keyIdx < animChan->mNumPositionKeys; ++keyIdx)
+      auto numKeys = std::max(
+          animChan->mNumPositionKeys, animChan->mNumRotationKeys);
+      // Position and rotation arrays might be different lengths,
+      // iterate over the maximum of the two, safely access by checking
+      // number of keys
+      for (unsigned keyIdx = 0; keyIdx < numKeys; ++keyIdx)
       {
         // Note, Scaling keys are not supported right now
         // Compute the position into a math pose
-        auto& posKey = animChan->mPositionKeys[keyIdx];
-        auto& quatKey = animChan->mRotationKeys[std::min(keyIdx, animChan->mNumRotationKeys - 1)];
+        auto& posKey = animChan->mPositionKeys[
+          std::min(keyIdx, animChan->mNumPositionKeys - 1)];
+        auto& quatKey = animChan->mRotationKeys[
+          std::min(keyIdx, animChan->mNumRotationKeys - 1)];
         math::Vector3d pos(posKey.mValue.x, posKey.mValue.y, posKey.mValue.z);
         math::Quaterniond quat(quatKey.mValue.w, quatKey.mValue.x,
             quatKey.mValue.y, quatKey.mValue.z);

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -688,7 +688,7 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
         // Note, Scaling keys are not supported right now
         // Compute the position into a math pose
         auto& posKey = animChan->mPositionKeys[keyIdx];
-        auto& quatKey = animChan->mRotationKeys[keyIdx];
+        auto& quatKey = animChan->mRotationKeys[std::min(keyIdx, animChan->mNumRotationKeys - 1)];
         math::Vector3d pos(posKey.mValue.x, posKey.mValue.y, posKey.mValue.z);
         math::Quaterniond quat(quatKey.mValue.w, quatKey.mValue.x,
             quatKey.mValue.y, quatKey.mValue.z);


### PR DESCRIPTION
# 🦟 Bug fix

Alternative to #478, it fixes the root cause of the issue that is undefined behavior due to access past the end of the array.

## Summary

When the parsing function was written, the assumption was that the position keys array and the rotation keys array would be the same length, this proved to not be the case since they can have different lengths.
The root cause of the issue addressed through #478 was that the rotation key array only had one element while the position key array was much longer, hence we were accessing values past the end of the array which is undefined behavior and can cause all sorts of trouble to downstream users.
Other cases with other animations can cause NaN exceptions in OGRE2 that crash the whole application.

With this PR we iterate over the longest of the arrays (to make sure no data is lost) and set the access to the position / rotation keys to be the minimum between the current index and the length of the array, to avoid undefined behavior.
This means that the last key will be duplicated in case the array is shorter, but that is acceptable behavior. It seems assimp returns a rotation array of length 1 to denote that rotation does not change throughout the animation.

The first one-line commit fixes the issue we are personally observing but I added https://github.com/gazebosim/gz-common/commit/f2cb2ce011b75966849b5b946c39bfa882682820 to fix the symmetrical case

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
