### PR TITLE
Fixed metalness/roughness in ASSIMP loader

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -316,6 +316,8 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   MaterialPtr mat = std::make_shared<Material>();
   aiColor4D color;
   bool specularDefine = false;
+  // gcc is complaining about this variable not being used.
+  (void) specularDefine;
   auto& assimpMat = _scene->mMaterials[_matIdx];
   auto ret = assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, color);
   if (ret == AI_SUCCESS)

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -315,6 +315,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
 {
   MaterialPtr mat = std::make_shared<Material>();
   aiColor4D color;
+  bool specularDefine = false;
   auto& assimpMat = _scene->mMaterials[_matIdx];
   auto ret = assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, color);
   if (ret == AI_SUCCESS)
@@ -324,6 +325,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   ret = assimpMat->Get(AI_MATKEY_COLOR_AMBIENT, color);
   if (ret == AI_SUCCESS)
   {
+    specularDefine = true;
     mat->SetAmbient(this->ConvertColor(color));
   }
   ret = assimpMat->Get(AI_MATKEY_COLOR_SPECULAR, color);
@@ -448,10 +450,14 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     pbr.SetLightMap(texName, uvIdx, texData);
   }
 #ifndef GZ_ASSIMP_PRE_5_2_0
-  double value;
+  float value;
   ret = assimpMat->Get(AI_MATKEY_METALLIC_FACTOR, value);
   if (ret == AI_SUCCESS)
   {
+    if (!specularDefine)
+    {
+      mat->SetSpecular(math::Color(value, value, value));
+    }
     pbr.SetMetalness(value);
   }
   ret = assimpMat->Get(AI_MATKEY_ROUGHNESS_FACTOR, value);


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Fixed metalness/roughness in ASSIMP loader

These values are float not double that's why the return value were always bad.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
