### PR TITLE
Fix for ffmpeg v6

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -264,8 +264,10 @@ bool AudioDecoder::SetFile(const std::string &_filename)
     return false;
   }
 
+#if LIBAVCODEC_VERSION_MAJOR < 60
   if (this->dataPtr->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
     this->dataPtr->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 
   // Open codec
   if (avcodec_open2(this->dataPtr->codecCtx,

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -194,10 +194,12 @@ bool Video::Load(const std::string &_filename)
     return false;
   }
 
+#if LIBAVCODEC_VERSION_MAJOR < 60
   // Inform the codec that we can handle truncated bitstreams -- i.e.,
   // bitstreams where frame boundaries can fall in the middle of packets
   if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
     this->dataPtr->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 
   // Open codec
   if (avcodec_open2(this->dataPtr->codecCtx, codec, nullptr) < 0)


### PR DESCRIPTION
# 🦟 Bug fix

This is fixing the fact that in AVCodec version 6 and above, the `AV_CODEC_CAP_TRUNCATED` has been removed, and thus `gz-common` was not compiling.
