### PR TITLE
Add support for bayer images to be saved in a directory

### DIFF
--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -26,7 +26,6 @@
 #include <gz/common/Util.hh>
 #include <gz/common/Image.hh>
 
-#include <iostream>
 
 using namespace gz;
 using namespace common;
@@ -246,7 +245,6 @@ void Image::SetFromData(const unsigned char *_data,
             (_format == BAYER_GBRG8) ||
             (_format == BAYER_GRBG8))
   {
-    std::cout << "teju to save\n";
     bpp = 8;
     scanlineBytes = _width;
   }  

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -241,13 +241,13 @@ void Image::SetFromData(const unsigned char *_data,
     bluemask = 0xff0000;
     scanlineBytes = _width * 3;
   }
-  else if (_format == BAYER_RGGB8)
+  else if ((_format == BAYER_RGGB8) ||
+            (_format == BAYER_BGGR8) ||
+            (_format == BAYER_GBRG8) ||
+            (_format == BAYER_GRBG8))
   {
     std::cout << "teju to save\n";
     bpp = 8;
-    // redmask = 0xff000000;
-    // greenmask = 0x00ff0000;
-    // bluemask = 0x0000ff00;
     scanlineBytes = _width;
   }  
   else

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -26,7 +26,6 @@
 #include <gz/common/Util.hh>
 #include <gz/common/Image.hh>
 
-
 using namespace gz;
 using namespace common;
 
@@ -241,9 +240,9 @@ void Image::SetFromData(const unsigned char *_data,
     scanlineBytes = _width * 3;
   }
   else if ((_format == BAYER_RGGB8) ||
-            (_format == BAYER_BGGR8) ||
-            (_format == BAYER_GBRG8) ||
-            (_format == BAYER_GRBG8))
+           (_format == BAYER_BGGR8) ||
+           (_format == BAYER_GBRG8) ||
+           (_format == BAYER_GRBG8))
   {
     bpp = 8;
     scanlineBytes = _width;

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -26,6 +26,8 @@
 #include <gz/common/Util.hh>
 #include <gz/common/Image.hh>
 
+#include <iostream>
+
 using namespace gz;
 using namespace common;
 
@@ -239,6 +241,15 @@ void Image::SetFromData(const unsigned char *_data,
     bluemask = 0xff0000;
     scanlineBytes = _width * 3;
   }
+  else if (_format == BAYER_RGGB8)
+  {
+    std::cout << "teju to save\n";
+    bpp = 8;
+    // redmask = 0xff000000;
+    // greenmask = 0x00ff0000;
+    // bluemask = 0x0000ff00;
+    scanlineBytes = _width;
+  }  
   else
   {
     gzerr << "Unable to handle format[" << _format << "]\n";


### PR DESCRIPTION
# 🎉 New feature

Closes [`gz-sensors` issue 299](https://github.com/gazebosim/gz-sensors/issues/299) 

## Sub-Tasks
-  [x] Support  simulation for `BAYER_RGGB8` with `OGRE`
-  [x] Extend the functionality to support all bayer types with `OGRE`
-  [x] Extend the functionality to support with `OGRE2`


## Summary and Related PRs
The functionality reads the user input and renders an RGB image, which is later converted into a single channel 8bit Bayer image using `ConvertRGBToBayer()` added to [`Utils.cc`](https://github.com/gazebosim/gz-rendering/blob/gz-rendering7/src/Utils.cc) inside `gz-rendering`.

* `gz-sensors` : Adds a switch case for `RGGB bayer format` inside `CameraSensor.cc` and passes the `R8G8B8` format to render the image.
* `gz-redering` : Adds `ConvertRGBToBayer()` to `Utils.cc`, modifies `OgreRenderTarget.cc` to call the conversion function, and handles image format conversion functions with `if-else` statements.
* `gz-gui` : Adds switch cases to display Bayer images in Gazebo GUI inside. It treats them as single-channel 8-bit images.
* `gz-common` : Modifies `Image::SetFromData` inside `Image.cc` to support saving of Bayer images. In order to save it It treats them as single-channel 8-bit images.

## Test it
In order to test this, one can modify `camera_sensor.sdf` inside `gz-sim` [here](https://github.com/gazebosim/gz-sim/blob/gz-sim7/examples/worlds/camera_sensor.sdf#L291). Would have just to replace the part with the following snippet.
```xml
<image>
   <width>320</width>
   <height>240</height>
   <format>BAYER_RGGB8</format>
</image>
<clip>
   <near>0.1</near>
   <far>100</far>
</clip>
<save enabled="true">
    <path>path to the folder</path>
</save>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
