### PR TITLE
Backport #497 to ign-common3: Fix for ffmpeg v6

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -345,8 +345,10 @@ bool AudioDecoder::SetFile(const std::string &_filename)
   }
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 60, 100)
+#if LIBAVCODEC_VERSION_MAJOR < 60
   if (this->data->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
     this->data->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 #else
   if (this->data->codec->capabilities & CODEC_CAP_TRUNCATED)
     this->data->codecCtx->flags |= CODEC_FLAG_TRUNCATED;

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -182,8 +182,10 @@ bool Video::Load(const std::string &_filename)
   // Inform the codec that we can handle truncated bitstreams -- i.e.,
   // bitstreams where frame boundaries can fall in the middle of packets
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 60, 100)
+#if LIBAVCODEC_VERSION_MAJOR < 60
   if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
     this->dataPtr->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 #else
   if (codec->capabilities & CODEC_CAP_TRUNCATED)
     this->dataPtr->codecCtx->flags |= CODEC_FLAG_TRUNCATED;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #503 

## Summary

Backport #497 to `ign-common3` to fix a build failure with ffmpeg 6.0 on macOS.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**.
