### PR TITLE
Include cstdint to build with GCC 13

### DIFF
--- a/profiler/src/ProfilerImpl.hh
+++ b/profiler/src/ProfilerImpl.hh
@@ -19,6 +19,7 @@
 #define GZ_COMMON_PROFILERIMPL_HH_
 
 #include <string>
+#include <cstdint>
 
 namespace ignition
 {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
Building with GCC 13 will fail due to `uint32_t` in: https://github.com/gazebosim/gz-common/blob/ec86532d6910e8e9068bc9425fb4374fdd00cbc7/profiler/src/ProfilerImpl.hh#L56

This PR can (and should) be included in newer versions too.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.