### PR TITLE
Only build mesh integration tests if graphics libraries are built

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -5,6 +5,10 @@ if (SKIP_av OR INTERNAL_SKIP_av)
   list(REMOVE_ITEM tests video_encoder.cc)
 endif()
 
+if (SKIP_graphics OR INTERNAL_SKIP_graphics)
+  list(REMOVE_ITEM tests mesh.cc)
+endif()
+
 gz_build_tests(
   TYPE INTEGRATION
   SOURCES ${tests}
@@ -19,10 +23,12 @@ if(TARGET INTEGRATION_plugin)
   target_include_directories(INTEGRATION_plugin PRIVATE ${PROJECT_SOURCE_DIR}/test)
 endif()
 
+# Graphics specific integration tests
 if(TARGET INTEGRATION_mesh)
   target_link_libraries(INTEGRATION_mesh ${PROJECT_LIBRARY_TARGET_NAME}-graphics)
 endif()
 
+# AV specific integration tests
 if(TARGET INTEGRATION_encoder_timing)
   target_link_libraries(INTEGRATION_encoder_timing ${PROJECT_LIBRARY_TARGET_NAME}-av)
 endif()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #522 

## Summary

This removes `mesh.cc` if the graphics component is not built either by being disabled by the user or from missing dependencies.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.