### PR TITLE
Missing cstdint header to use uint32_t with gcc-13

### DIFF
--- a/profiler/src/ProfilerImpl.hh
+++ b/profiler/src/ProfilerImpl.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_COMMON_PROFILERIMPL_HH_
 #define GZ_COMMON_PROFILERIMPL_HH_
 
+#include <cstdint>
 #include <string>
 
 namespace ignition


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Build fails in Debian Sid with gcc-13:
```bash
In file included from /home/jrivero/code/debian/ignition-common/profiler/src/RemoteryProfilerImpl.hh:26,
                 from /home/jrivero/code/debian/ignition-common/profiler/src/RemoteryProfilerImpl.cc:20:
/home/jrivero/code/debian/ignition-common/profiler/src/ProfilerImpl.hh:56:59: error: ‘uint32_t’ has not been declared
   56 |       public: virtual void BeginSample(const char *_name, uint32_t *_hash) = 0;
      |                                                           ^~~~~~~~
/home/jrivero/code/debian/ignition-common/profiler/src/RemoteryProfilerImpl.hh:74:51: error: ‘uint32_t’ has not been declared
   74 |       public: void BeginSample(const char *_name, uint32_t *_hash) final;
      |                                                   ^~~~~~~~
/home/jrivero/code/debian/ignition-common/profiler/src/RemoteryProfilerImpl.cc:226:6: error: no declaration matches ‘void ignition::common::RemoteryProfilerImpl::BeginSample(const char*, uint32_t*)’
  226 | void RemoteryProfilerImpl::BeginSample(const char *_name, uint32_t *_hash)
      |      ^~~~~~~~~~~~~~~~~~~~
/home/jrivero/code/debian/ignition-common/profiler/src/RemoteryProfilerImpl.hh:74:20: note: candidate is: ‘virtual void ignition::common::RemoteryProfilerImpl::BeginSample(const char*, int*)’
   74 |       public: void BeginSample(const char *_name, uint32_t *_hash) final;
      |                    ^~~~~~~~~~~
/home/jrivero/code/debian/ignition-common/profiler/src/RemoteryProfilerImpl.hh:47:11: note: ‘class ignition::common::RemoteryProfilerImpl’ defined here
   47 |     class RemoteryProfilerImpl: public ProfilerImpl
      |           ^~~~~~~~~~~~~~~~~~~~
make[3]: *** [profiler/src/CMakeFiles/ignition-common4-profiler.dir/build.make:107: profiler/src/CMakeFiles/ignition-common4-profiler.dir/RemoteryProfilerImpl.cc.o] Error 1
make[3]: Leaving directory '/home/jrivero/code/debian/ignition-common/obj-x86_64-linux-gnu'
make[2]: *** [CMakeFiles/Makefile2:3257: profiler/src/CMakeFiles/ignition-common4-profiler.dir/all] Error 2
make[2]: Leaving directory '/home/jrivero/code/debian/ignition-common/obj-x86_64-linux-gnu'
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.