### PR TITLE
Remove deprecated std::iterator inheritance

### DIFF
--- a/include/gz/common/EnumIface.hh
+++ b/include/gz/common/EnumIface.hh
@@ -226,22 +226,23 @@ namespace gz::common
   {
     return !(_e1 == _e2);
   }
+
+  /// \brief A template that allows an enum to have an iterator and string
+  /// conversion.
+  /// \param[in] begin Enum value that marks the beginning of the enum
+  /// values.
+  /// \param[in] end Enum value that marks the end of the enum values.
+  /// \param[in] names A vector of strings, one for each enum value.
+  /// \sa EnumIface
+  /// \sa EnumIterator
+  template<typename T>
+  static constexpr gz::common::EnumIface<T> gzEnum(
+    T _enumBegin, T _enumEnd, const std::vector<std::string> &_enumVals)
+  {
+    return gz::common::EnumIface<T>(_enumBegin, _enumEnd, _enumVals);
+  }
 }  // namespace gz::common
 
-/// \brief A template that allows an enum to have an iterator and string
-/// conversion.
-/// \param[in] begin Enum value that marks the beginning of the enum
-/// values.
-/// \param[in] end Enum value that marks the end of the enum values.
-/// \param[in] names A vector of strings, one for each enum value.
-/// \sa EnumIface
-/// \sa EnumIterator
-template<typename T>
-static constexpr gz::common::EnumIface<T> gzEnum(
-  T _enumBegin, T _enumEnd, const std::vector<std::string> &_enumVals)
-{
-  return gz::common::EnumIface<T>(_enumBegin, _enumEnd, _enumVals);
-}
 
 /// \brief A macro that allows an enum to have an iterator and string
 /// conversion.
@@ -254,6 +255,6 @@ static constexpr gz::common::EnumIface<T> gzEnum(
 /// \sa EnumIface
 /// \sa EnumIterator
 #define GZ_ENUM(name, enumType, begin, end, ...)  \
-static auto name = gzEnum(begin, end, {__VA_ARGS__});
+static auto name = gz::common::gzEnum(begin, end, {__VA_ARGS__});
 
 #endif  // GZ_COMMON_ENUMITERATOR_HH_

--- a/include/gz/common/EnumIface.hh
+++ b/include/gz/common/EnumIface.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_COMMON_ENUMITERATOR_HH_
 #define GZ_COMMON_ENUMITERATOR_HH_
 
+#include <iterator>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -24,220 +25,235 @@
 #include <gz/common/Export.hh>
 #include <gz/common/Util.hh>
 
-namespace gz
+namespace gz::common
 {
-  namespace common
+  /// \brief Enum interface. Use this interface to convert an enum to
+  /// a string, and set an enum from a string.
+  template<typename T>
+  class EnumIface
   {
-    /// \brief A macro that allows an enum to have an iterator and string
-    /// conversion.
-    /// \param[in] name EnumIface instance name.
-    /// \param[in] enumType Enum type
-    /// \param[in] begin Enum value that marks the beginning of the enum
-    /// values.
-    /// \param[in] end Enum value that marks the end of the enum values.
-    /// \param[in] names A vector of strings, one for each enum value.
-    /// \sa EnumIface
+    /// \brief Constructor
+    /// \param[in] _start Starting enum value.
+    /// \param[in] _end Ending enum value.
+    /// \param[in] _names Name of each enum value.
+    public: EnumIface(T _start, T _end,
+        const std::vector<std::string> &_names)
+            : names(_names)
+    {
+      this->range[0] = _start;
+      this->range[1] = _end;
+    }
+
+    /// \brief Get the beginning enum value.
+    /// \return Enum value that marks the beginning of the enum list.
+    public: T Begin()
+    {
+      return range[0];
+    }
+
+    /// \brief Get the end enum value.
+    /// \return Enum value that marks the end of the enum list.
+    public: T End()
+    {
+      return range[1];
+    }
+
+    /// \brief Convert enum value to string.
+    /// \param[in] _e Enum value to convert.
+    /// \return String representation of the enum. An empty string is
+    /// returned if _e is invalid, or the names for the enum have not been
+    /// set.
+    public: std::string Str(T const &_e)
+    {
+      std::string ret;
+      if (static_cast<unsigned int>(_e) < names.size())
+        ret = names[static_cast<unsigned int>(_e)];
+      return ret;
+    }
+
+    /// \brief Set an enum from a string. This function requires a valid
+    /// string, and an array of names for the enum must exist.
+    /// \param[in] _str String value to convert to enum value.
+    /// \param[in] _e Enum variable to set.
     /// \sa EnumIterator
-    #define GZ_ENUM(name, enumType, begin, end, ...) \
-    static gz::common::EnumIface<enumType> name( \
-        begin, end, {__VA_ARGS__});
-
-    /// \brief Enum interface. Use this interface to convert an enum to
-    /// a string, and set an enum from a string.
-    template<typename T>
-    class EnumIface
+    public: void Set(T &_e, const std::string &_str)
     {
-      /// \brief Constructor
-      /// \param[in] _start Starting enum value.
-      /// \param[in] _end Ending enum value.
-      /// \param[in] _names Name of each enum value.
-      public: EnumIface(T _start, T _end,
-          const std::vector<std::string> &_names)
-              : names(_names)
+      auto begin = std::begin(names);
+      auto end = std::end(names);
+
+      auto find = std::find(begin, end, _str);
+      if (find != end)
       {
-        this->range[0] = _start;
-        this->range[1] = _end;
+        _e = static_cast<T>(std::distance(begin, find));
       }
-
-      /// \brief Get the beginning enum value.
-      /// \return Enum value that marks the beginning of the enum list.
-      public: T Begin()
-      {
-        return range[0];
-      }
-
-      /// \brief Get the end enum value.
-      /// \return Enum value that marks the end of the enum list.
-      public: T End()
-      {
-        return range[1];
-      }
-
-      /// \brief Convert enum value to string.
-      /// \param[in] _e Enum value to convert.
-      /// \return String representation of the enum. An empty string is
-      /// returned if _e is invalid, or the names for the enum have not been
-      /// set.
-      public: std::string Str(T const &_e)
-      {
-        if (static_cast<unsigned int>(_e) < names.size())
-          return names[static_cast<unsigned int>(_e)];
-        else
-          return "";
-      }
-
-      /// \brief Set an enum from a string. This function requires a valid
-      /// string, and an array of names for the enum must exist.
-      /// \param[in] _str String value to convert to enum value.
-      /// \param[in] _e Enum variable to set.
-      /// \sa EnumIterator
-      public: void Set(T &_e, const std::string &_str)
-      {
-        auto begin = std::begin(names);
-        auto end = std::end(names);
-
-        auto find = std::find(begin, end, _str);
-        if (find != end)
-        {
-          _e = static_cast<T>(std::distance(begin, find));
-        }
-      }
-
-      /// \internal
-      /// \brief The beginning and end values. Do not use this directly.
-      public: T range[2];
-
-      /// \internal
-      /// \brief Array of string names for each element in the enum. Do not
-      /// use this directly.
-      public: std::vector<std::string> names;
-    };
-
-    /// \brief An iterator over enum types.
-    ///
-    ///  Example:
-    ///
-    /// \verbatim
-    /// enum MyType
-    /// {
-    ///   MY_TYPE_BEGIN = 0,
-    ///   TYPE1 = MY_TYPE_BEGIN,
-    ///   TYPE2 = 1,
-    ///   MY_TYPE_END
-    /// };
-    ///
-    /// GZ_ENUM(myTypeIface, MyType, MY_TYPE_BEGIN, MY_TYPE_END,
-    ///  "TYPE1",
-    ///  "TYPE2",
-    ///  "MY_TYPE_END")
-    ///
-    /// int main()
-    /// {
-    ///   EnumIterator<MyType> i = MY_TYPE_BEGIN;
-    ///   std::cout << "Type Number[" << *i << "]\n";
-    ///   std::cout << "Type Name[" << myTypeIface.Str(*i) << "]\n";
-    ///   i++;
-    ///   std::cout << "Type++ Number[" << *i << "]\n";
-    ///   std::cout << "Type++ Name[" << myTypeIface.Str(*i) << "]\n";
-    /// }
-    /// \verbatim
-    template<typename Enum>
-    class EnumIterator
-    : std::iterator<std::bidirectional_iterator_tag, Enum>
-    {
-      /// \brief Constructor
-      public: EnumIterator()
-      {
-      }
-
-      /// \brief Constructor
-      /// \param[in] _c Enum value
-      // cppcheck-suppress noExplicitConstructor
-      public: EnumIterator(const Enum &_c) : c(_c)
-      {
-      }
-
-      /// \brief Equal operator
-      /// \param[in] _c Enum value to copy
-      public: EnumIterator &operator=(const Enum &_c)
-      {
-        this->c = _c;
-        return *this;
-      }
-
-      /// \brief Prefix increment operator.
-      /// \return Iterator pointing to the next value in the enum.
-      public: EnumIterator &operator++()
-      {
-        this->c = static_cast<Enum>(static_cast<int>(this->c) + 1);
-        return *this;
-      }
-
-      /// \brief Postfix increment operator.
-      /// \return Iterator pointing to the next value in the enum.
-      public: EnumIterator operator++(const int)
-      {
-        EnumIterator cpy(*this);
-        ++*this;
-        return cpy;
-      }
-
-      /// \brief Prefix decrement operator
-      /// \return Iterator pointing to the previous value in the enum
-      public: EnumIterator &operator--()
-      {
-        this->c = static_cast<Enum>(static_cast<int>(this->c) - 1);
-        return *this;
-      }
-
-      /// \brief Postfix decrement operator
-      /// \return Iterator pointing to the previous value in the enum
-      public: EnumIterator operator--(const int)
-      {
-        EnumIterator cpy(*this);
-        --*this;
-        return cpy;
-      }
-
-      /// \brief Dereference operator
-      /// \return Value of the iterator
-      public: Enum operator*() const
-      {
-        return c;
-      }
-
-      /// \brief Get the enum value.
-      /// \return Value of the iterator
-      public: Enum Value() const
-      {
-        return this->c;
-      }
-
-      /// \brief Enum value
-      /// Did not use a private data class since this should be the only
-      /// member value ever used.
-      private: Enum c;
-    };
-
-    /// \brief Equality operator
-    /// \param[in] _e1 First iterator
-    /// \param[in] _e1 Second iterator
-    /// \return True if the two iterators contain equal enum values.
-    template<typename Enum>
-    bool operator==(EnumIterator<Enum> _e1, EnumIterator<Enum> _e2)
-    {
-      return _e1.Value() == _e2.Value();
     }
 
-    /// \brief Inequality operator
-    /// \param[in] _e1 First iterator
-    /// \param[in] _e1 Second iterator
-    /// \return True if the two iterators do not contain equal enum values.
-    template<typename Enum>
-    bool operator!=(EnumIterator<Enum> _e1, EnumIterator<Enum> _e2)
+    /// \internal
+    /// \brief The beginning and end values. Do not use this directly.
+    public: T range[2];
+
+    /// \internal
+    /// \brief Array of string names for each element in the enum. Do not
+    /// use this directly.
+    public: std::vector<std::string> names;
+  };
+
+  /// \brief An iterator over enum types.
+  ///
+  ///  Example:
+  ///
+  /// \verbatim
+  /// enum MyType
+  /// {
+  ///   MY_TYPE_BEGIN = 0,
+  ///   TYPE1 = MY_TYPE_BEGIN,
+  ///   TYPE2 = 1,
+  ///   MY_TYPE_END
+  /// };
+  ///
+  /// auto myTypeIface = gzEnum(MY_TYPE_BEGIN, MY_TYPE_END,
+  ///  {"TYPE1",
+  ///  "TYPE2",
+  ///  "MY_TYPE_END"});
+  ///
+  /// int main()
+  /// {
+  ///   EnumIterator<MyType> i = MY_TYPE_BEGIN;
+  ///   std::cout << "Type Number[" << *i << "]\n";
+  ///   std::cout << "Type Name[" << myTypeIface.Str(*i) << "]\n";
+  ///   i++;
+  ///   std::cout << "Type++ Number[" << *i << "]\n";
+  ///   std::cout << "Type++ Name[" << myTypeIface.Str(*i) << "]\n";
+  /// }
+  /// \verbatim
+  template<typename Enum>
+  class EnumIterator
+  {
+    public: using iterator_category = std::bidirectional_iterator_tag;
+    public: using value_type = Enum;
+    public: using difference_type = std::ptrdiff_t;
+    public: using pointer = Enum*;
+    public: using reference = Enum&;
+
+    /// \brief Constructor
+    public: EnumIterator() = default;
+
+    /// \brief Constructor
+    /// \param[in] _c Enum value
+    // cppcheck-suppress noExplicitConstructor
+    public: explicit EnumIterator(const Enum &_c) : c(_c)
     {
-      return !(_e1 == _e2);
     }
+
+    /// \brief Equal operator
+    /// \param[in] _c Enum value to copy
+    public: EnumIterator &operator=(const Enum &_c)
+    {
+      this->c = _c;
+      return *this;
+    }
+
+    /// \brief Prefix increment operator.
+    /// \return Iterator pointing to the next value in the enum.
+    public: EnumIterator &operator++()
+    {
+      this->c = static_cast<Enum>(static_cast<int>(this->c) + 1);
+      return *this;
+    }
+
+    /// \brief Postfix increment operator.
+    /// \return Iterator pointing to the next value in the enum.
+    public: EnumIterator operator++(const int)
+    {
+      EnumIterator cpy(*this);
+      ++*this;
+      return cpy;
+    }
+
+    /// \brief Prefix decrement operator
+    /// \return Iterator pointing to the previous value in the enum
+    public: EnumIterator &operator--()
+    {
+      this->c = static_cast<Enum>(static_cast<int>(this->c) - 1);
+      return *this;
+    }
+
+    /// \brief Postfix decrement operator
+    /// \return Iterator pointing to the previous value in the enum
+    public: EnumIterator operator--(const int)
+    {
+      EnumIterator cpy(*this);
+      --*this;
+      return cpy;
+    }
+
+    /// \brief Dereference operator
+    /// \return Value of the iterator
+    public: Enum operator*() const
+    {
+      return c;
+    }
+
+    /// \brief Get the enum value.
+    /// \return Value of the iterator
+    public: Enum Value() const
+    {
+      return this->c;
+    }
+
+    /// \brief Enum value
+    /// Did not use a private data class since this should be the only
+    /// member value ever used.
+    private: Enum c;
+  };
+
+  /// \brief Equality operator
+  /// \param[in] _e1 First iterator
+  /// \param[in] _e1 Second iterator
+  /// \return True if the two iterators contain equal enum values.
+  template<typename Enum>
+  bool operator==(EnumIterator<Enum> _e1, EnumIterator<Enum> _e2)
+  {
+    return _e1.Value() == _e2.Value();
   }
+
+  /// \brief Inequality operator
+  /// \param[in] _e1 First iterator
+  /// \param[in] _e1 Second iterator
+  /// \return True if the two iterators do not contain equal enum values.
+  template<typename Enum>
+  bool operator!=(EnumIterator<Enum> _e1, EnumIterator<Enum> _e2)
+  {
+    return !(_e1 == _e2);
+  }
+}  // namespace gz::common
+
+/// \brief A template that allows an enum to have an iterator and string
+/// conversion.
+/// \param[in] begin Enum value that marks the beginning of the enum
+/// values.
+/// \param[in] end Enum value that marks the end of the enum values.
+/// \param[in] names A vector of strings, one for each enum value.
+/// \sa EnumIface
+/// \sa EnumIterator
+template<typename T>
+static constexpr gz::common::EnumIface<T> gzEnum(
+  T _enumBegin, T _enumEnd, const std::vector<std::string> &_enumVals)
+{
+  return gz::common::EnumIface<T>(_enumBegin, _enumEnd, _enumVals);
 }
-#endif
+
+/// \brief A macro that allows an enum to have an iterator and string
+/// conversion.
+/// \param[in] name EnumIface instance name.
+/// \param[in] enumType Enum type
+/// \param[in] begin Enum value that marks the beginning of the enum
+/// values.
+/// \param[in] end Enum value that marks the end of the enum values.
+/// \param[in] names A vector of strings, one for each enum value.
+/// \sa EnumIface
+/// \sa EnumIterator
+#define GZ_ENUM(name, enumType, begin, end, ...)  \
+static auto name = gzEnum(begin, end, {__VA_ARGS__});
+
+#endif  // GZ_COMMON_ENUMITERATOR_HH_

--- a/src/EnumIface_TEST.cc
+++ b/src/EnumIface_TEST.cc
@@ -33,11 +33,12 @@ enum MyType
   MY_TYPE_END
 };
 
-GZ_ENUM(myTypeIface, MyType, MY_TYPE_BEGIN, MY_TYPE_END,
-  "TYPE1",
-  "TYPE2",
-  "MY_TYPE_END"
-)
+auto myTypeIface = gz::common::gzEnum(
+  MY_TYPE_BEGIN, MY_TYPE_END, {
+    "TYPE1",
+    "TYPE2",
+    "MY_TYPE_END"
+});
 
 /////////////////////////////////////////////////
 TEST_F(EnumIfaceTest, StringCoversion)
@@ -58,16 +59,16 @@ TEST_F(EnumIfaceTest, StringCoversion)
 /////////////////////////////////////////////////
 TEST_F(EnumIfaceTest, Iterator)
 {
-  common::EnumIterator<MyType> end = MY_TYPE_END;
+  common::EnumIterator<MyType> end {MY_TYPE_END};
   ASSERT_EQ(end.Value(), MY_TYPE_END);
 
-  common::EnumIterator<MyType> begin = MY_TYPE_BEGIN;
+  common::EnumIterator<MyType> begin {MY_TYPE_BEGIN};
   ASSERT_EQ(*begin, MY_TYPE_BEGIN);
 
   int i = 0;
 
   // Prefix ++ operator
-  for (common::EnumIterator<MyType> typeIter = MY_TYPE_BEGIN;
+  for (common::EnumIterator<MyType> typeIter {MY_TYPE_BEGIN};
        typeIter != end; ++typeIter, ++i)
   {
     ASSERT_EQ(*typeIter, i);
@@ -79,7 +80,7 @@ TEST_F(EnumIfaceTest, Iterator)
 
   // Postfix ++ operator
   i = 0;
-  for (common::EnumIterator<MyType> typeIter = MY_TYPE_BEGIN;
+  for (common::EnumIterator<MyType> typeIter {MY_TYPE_BEGIN};
        typeIter != end; ++typeIter, ++i)
   {
     ASSERT_EQ(typeIter.Value(), i);
@@ -103,7 +104,7 @@ TEST_F(EnumIfaceTest, Iterator)
 
   // Postfix -- operator
   i = MY_TYPE_END - 1;
-  common::EnumIterator<MyType> end2 = MY_TYPE_END;
+  common::EnumIterator<MyType> end2{MY_TYPE_END};
   for (common::EnumIterator<MyType> typeIter = --end2;
        typeIter != begin; --typeIter, --i)
   {

--- a/src/EnumIface_TEST.cc
+++ b/src/EnumIface_TEST.cc
@@ -21,7 +21,9 @@
 
 #include "gz/common/testing/AutoLogFixture.hh"
 
-class EnumIfaceTest : public gz::common::testing::AutoLogFixture { };
+using namespace gz;
+
+class EnumIfaceTest : public common::testing::AutoLogFixture { };
 
 enum MyType
 {

--- a/src/EnumIface_TEST.cc
+++ b/src/EnumIface_TEST.cc
@@ -21,9 +21,7 @@
 
 #include "gz/common/testing/AutoLogFixture.hh"
 
-using namespace gz;
-
-class EnumIfaceTest : public common::testing::AutoLogFixture { };
+class EnumIfaceTest : public gz::common::testing::AutoLogFixture { };
 
 enum MyType
 {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #505

## Summary

Removes the use of the deprecated std::iterator template and replaces it with using the correct set of `using` statements.

I also added a `gzEnum` variadic template at clang's suggestion.  This should probably be preferred over the macro where relevant.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
