### PR TITLE
Prepare for 5.4.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.4.0)
+project(gz-common5 VERSION 5.4.1)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,40 @@
 ## Gazebo Common 5.x
 
+## Gazebo Common 5.4.1 (2023-08-21)
+
+1. Use `pull_request_target`  for triage workflow
+    * [Pull request #527](https://github.com/gazebosim/gz-common/pull/527)
+
+1. Fix Github project automation for new project board
+    * [Pull request #526](https://github.com/gazebosim/gz-common/pull/526)
+
+1. Fix Github Actions on macOS
+    * [Pull request #524](https://github.com/gazebosim/gz-common/pull/524)
+
+1. Only build integration tests if libraries exist
+    * [Pull request #523](https://github.com/gazebosim/gz-common/pull/523)
+
+1. Fix compiling under linux
+    * [Pull request #521](https://github.com/gazebosim/gz-common/pull/521)
+
+1. Add missing <fstream> header includes
+    * [Pull request #518](https://github.com/gazebosim/gz-common/pull/518)
+
+1. Header was dropped in the forward port and breaks downstream
+    * [Pull request #515](https://github.com/gazebosim/gz-common/pull/515)
+
+1. Port: 4 to 5
+    * [Pull request #511](https://github.com/gazebosim/gz-common/pull/511)
+
+1. Lint
+    * [Pull request #Lint](https://github.com/gazebosim/gz-common/pull/Lint)
+
+1. 🎈 4.7.0
+    * [Pull request #510](https://github.com/gazebosim/gz-common/pull/510)
+
+1. Fix build error when using gz:: with ign-common4
+    * [Pull request #489](https://github.com/gazebosim/gz-common/pull/489)
+
 ## Gazebo Common 5.4.0 (2023-04-28)
 
 1. Add support for bayer images to be saved in a directory


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.4.1 release.

Comparison to 5.4.0: https://github.com/gazebosim/gz-common/compare/gz-common5_5.4.0...gz-common5

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
