### PR TITLE
Fix glTF metalness and roughness map orientation

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -507,13 +507,13 @@ std::pair<ImagePtr, ImagePtr>
   std::vector<unsigned char> metalnessData(width * height * bytesPerPixel);
   std::vector<unsigned char> roughnessData(width * height * bytesPerPixel);
 
-  for (unsigned int x = 0; x < width; ++x)
+  for (unsigned int y = 0; y < height; ++y)
   {
-    for (unsigned int y = 0; y < height; ++y)
+    for (unsigned int x = 0; x < width; ++x)
     {
       // RGBA so 4 bytes per pixel, alpha fully opaque
-      auto baseIndex = bytesPerPixel * (x * height + y);
-      auto color = _img.Pixel(x, y);
+      auto baseIndex = bytesPerPixel * (y * width + x);
+      auto color = _img.Pixel(x, (height - y - 1));
       metalnessData[baseIndex] = color.B() * 255.0;
       metalnessData[baseIndex + 1] = color.B() * 255.0;
       metalnessData[baseIndex + 2] = color.B() * 255.0;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

glb file packs the metalness and roughness maps (grayscale) in a single texture (in the R and G channels) and our Assimp loader splits them out into individual textures for use in gz-rendering. However, the texture data are written out incorrectly (rotated by 90 degrees). This PR fixes that logic.

For testing, I'm using the water bottle glb file from: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/WaterBottle. You can see a screenshot of what the water bottle supposed to look like in that page.

Here're screenshots in gazebo showing before and after the fix:

Before:
<img width="531" alt="glb_before" src="https://github.com/gazebosim/gz-common/assets/4000684/eb0fecfd-2c78-4674-9e33-410b79f2fe23">

After:
<img width="527" alt="glb_after" src="https://github.com/gazebosim/gz-common/assets/4000684/fb527cf8-1973-4a3e-a79e-66d39ffcd06d">


Side note, with default lighting params in Gazebo, the bottle appears a lot darker than expected . In the screenshot above, I had to change the dir light diffuse and specular colors to [1.0 1.0 1.0] and intensity to 2.0 to get the water bottle to be brighter 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

