### PR TITLE
Prepare for 5.4.2 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.4.1)
+project(gz-common5 VERSION 5.4.2)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,18 @@
 ## Gazebo Common 5.x
 
+## Gazebo Common 5.4.2 (2023-09-26)
+
+1. Documentation fixes
+    * [Pull request #534](https://github.com/gazebosim/gz-common/pull/534)
+    * [Pull request #535](https://github.com/gazebosim/gz-common/pull/535)
+
+1. Fix glTF metalness and roughness map orientation
+    * [Pull request #532](https://github.com/gazebosim/gz-common/pull/532)
+
+1. Build examples from CMake rather than executable
+    * [Pull request #502](https://github.com/gazebosim/gz-common/pull/502)
+
+
 ## Gazebo Common 5.4.1 (2023-08-21)
 
 1. Use `pull_request_target`  for triage workflow


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.4.2 release.

Comparison to 5.4.1: https://github.com/gazebosim/gz-common/compare/gz-common5_5.4.1...gz-common5


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.