### PR TITLE
Prevent loading lightmaps if mesh is a glb file that has an occlusion-metallic-roughness texture

### DIFF
--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -708,10 +708,16 @@ TEST_F(AssimpLoader, LoadGlbPbrAsset)
   // Check pixel values to test metallicroughness texture splitting
   EXPECT_FLOAT_EQ(pbr->MetalnessMapData()->Pixel(256, 256).R(), 0.0);
   EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(), 124.0 / 255.0);
+
   // Bug in assimp 5.0.x that doesn't parse coordinate sets properly
-  EXPECT_EQ(pbr->LightMapTexCoordSet(), 1);
+  // \todo(iche033) Lightmaps are disabled for glb meshes
+  // due to upstream bug
+  // EXPECT_EQ(pbr->LightMapTexCoordSet(), 1);
 #endif
-  EXPECT_NE(pbr->LightMapData(), nullptr);
+
+  // \todo(iche033) Lightmaps are disabled for glb meshes
+  // due to upstream bug
+  // EXPECT_NE(pbr->LightMapData(), nullptr);
 
   // Mesh has 3 animations
   auto skel = mesh->MeshSkeleton();


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

When loading this [water bottle glb file](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/WaterBottle), I manually saved the lightmap texture file (loaded by assimp) to examine what it looks like. It turns out the lightmap texture is just a copy of the [occlusion-metallic-roughness](https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png) texture, which is not correct.  There are issues reported upstream (see inline comments in code).

Currently if an occlusion-metallic-roughness texture exists, we extract the roughness texture map from the `g` channel and the metalness map is in the `b` channel of this texture.  I suspect that the right thing to do is to extract the `r` channel as a separate occlusion texture and use that as the lightmap (not quite the same but occlusion maps are not yet supported in gz-rendering). This needs to be investigated. For now, this PR prevents setting incorrect lightmap textures for glb meshes.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
