### PR TITLE
EnumIface: suppress deprecation warning

### DIFF
--- a/include/gz/common/EnumIface.hh
+++ b/include/gz/common/EnumIface.hh
@@ -141,6 +141,7 @@ namespace gz
     ///   std::cout << "Type++ Name[" << myTypeIface.Str(*i) << "]\n";
     /// }
     /// \verbatim
+    GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
     template<typename Enum>
     class EnumIterator
     : std::iterator<std::bidirectional_iterator_tag, Enum>
@@ -218,6 +219,7 @@ namespace gz
       /// member value ever used.
       private: Enum c;
     };
+    GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
 
     /// \brief Equality operator
     /// \param[in] _e1 First iterator


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-common/issues/505, follow-up to #529.

## Summary

The EnumIterator class inherits from std::iterator, which has been deprecated in c++17. There is a fix in gz-common6 (#529) but it breaks API, so it can't be merged to Garden. So just suppress the deprecation warning in Garden.

This should fix the gz-common5 brew builds:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_common-ci-gz-common5-homebrew-amd64&build=75)](https://build.osrfoundation.org/view/ign-garden/job/ignition_common-ci-gz-common5-homebrew-amd64/75/) https://build.osrfoundation.org/view/ign-garden/job/ignition_common-ci-gz-common5-homebrew-amd64/75/


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
