### PR TITLE
Fix segfault in case of no write access to log dir

### DIFF
--- a/include/gz/common/Filesystem.hh
+++ b/include/gz/common/Filesystem.hh
@@ -63,7 +63,13 @@ namespace ignition
     /// \return True if directory creation was successful, false otherwise.
     bool IGNITION_COMMON_VISIBLE createDirectory(const std::string &_path);
 
-    /// \brief Create directories for the given path
+    /// \brief Create directories for the given path errors are printed to the given stream
+    /// \param[in] _path Path to create directories from
+    /// \param[in] _errorOut Stream for error output
+    /// \return true on success
+    bool IGNITION_COMMON_VISIBLE createDirectories(const std::string &_path, std::ostream &_errorOut);
+
+    /// \brief Create directories for the given path errors are printed on ignerr
     /// \param[in] _path Path to create directories from
     /// \return true on success
     bool IGNITION_COMMON_VISIBLE createDirectories(const std::string &_path);

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -277,7 +277,7 @@ void FileLogger::Init(const std::string &_directory,
   // Create the directory if it doesn't exist.
   if(!createDirectories(logPath, std::cerr))
   {
-      std::cerr << "Failed to generate log directories."
+      std::cerr << "Failed to generate log directories. "
                 << "No log file will be generated.";
       return;
   }

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -261,7 +261,7 @@ void FileLogger::Init(const std::string &_directory,
   {
     if (!env(IGN_HOMEDIR, logPath))
     {
-      std::cerr << "Missing HOME environment variable."
+      std::cerr << "Missing HOME environment variable. "
                 << "No log file will be generated.";
       return;
     }

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -261,8 +261,8 @@ void FileLogger::Init(const std::string &_directory,
   {
     if (!env(IGN_HOMEDIR, logPath))
     {
-      ignerr << "Missing HOME environment variable."
-        << "No log file will be generated.";
+      std::cerr << "Missing HOME environment variable."
+                << "No log file will be generated.";
       return;
     }
     logPath = joinPaths(logPath, _directory);
@@ -275,7 +275,12 @@ void FileLogger::Init(const std::string &_directory,
   auto* buf = dynamic_cast<FileLogger::Buffer*>(this->rdbuf());
 
   // Create the directory if it doesn't exist.
-  createDirectories(logPath);
+  if(!createDirectories(logPath, std::cerr))
+  {
+      std::cerr << "Failed to generate log directories."
+                << "No log file will be generated.";
+      return;
+  }
 
   logPath = joinPaths(logPath, _filename);
 

--- a/src/EnumIface_TEST.cc
+++ b/src/EnumIface_TEST.cc
@@ -41,7 +41,7 @@ IGN_ENUM(myTypeIface, MyType, MY_TYPE_BEGIN, MY_TYPE_END,
 /////////////////////////////////////////////////
 TEST_F(EnumIfaceTest, StringCoversion)
 {
-  MyType type;
+  MyType type = MyType::TYPE2;
 
   // Set value from string
   myTypeIface.Set(type, "TYPE1");

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -466,6 +466,12 @@ bool common::copyDirectory(const std::string &_existingDirname,
 /////////////////////////////////////////////////
 bool common::createDirectories(const std::string &_path)
 {
+  return createDirectories(_path, ignerr);
+}
+
+/////////////////////////////////////////////////
+bool common::createDirectories(const std::string &_path, std::ostream &_errorOut)
+{
   size_t index = 0;
   while (index < _path.size())
   {
@@ -482,8 +488,8 @@ bool common::createDirectories(const std::string &_path)
       if (mkdir(dir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0)
       {
 #endif
-        ignerr << "Failed to create directory [" + dir + "]: "
-               << std::strerror(errno) << std::endl;
+        _errorOut << "Failed to create directory [" + dir + "]: "
+                  << std::strerror(errno) << std::endl;
         return false;
       }
     }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a Segfault when building Ign common3 with pbuilder

## Summary
If there is no write access to the log directory, the logger will call itself recusively in an infinite loop and segfault.
Note, this bug is also present in the latest version of ign common.

