### PR TITLE
Add missing visibility declarations

### DIFF
--- a/profiler/src/RemoteryProfilerImpl.cc
+++ b/profiler/src/RemoteryProfilerImpl.cc
@@ -16,6 +16,7 @@
  */
 
 #include "gz/common/config.hh"
+#include <gz/common/profiler/Export.hh>
 
 #include "RemoteryProfilerImpl.hh"
 #include "gz/common/Console.hh"
@@ -24,6 +25,7 @@
 using namespace gz;
 using namespace common;
 
+GZ_COMMON_PROFILER_VISIBLE
 std::string rmtErrorToString(rmtError error) {
   switch (error) {
     case RMT_ERROR_NONE:

--- a/src/SignalHandler.cc
+++ b/src/SignalHandler.cc
@@ -31,7 +31,7 @@ using namespace gz;
 using namespace common;
 
 // A wrapper for the sigaction sa_handler.
-std::map<int, std::function<void(int)>> gOnSignalWrappers;
+GZ_COMMON_VISIBLE std::map<int, std::function<void(int)>> gOnSignalWrappers;
 std::mutex gWrapperMutex;
 
 /////////////////////////////////////////////////

--- a/testing/include/gz/common/testing/CMakeTestPaths.hh
+++ b/testing/include/gz/common/testing/CMakeTestPaths.hh
@@ -28,7 +28,7 @@ namespace gz::common::testing
 ///
 /// It is not intended that users will directly construct this, but rather
 /// utilize the TestPathFactory.
-class CMakeTestPaths: public TestPaths
+class GZ_COMMON_TESTING_VISIBLE CMakeTestPaths: public TestPaths
 {
   /// \brief Constructor from TestPaths
   public: using TestPaths::TestPaths;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
While testing https://github.com/gazebosim/gz-cmake/pull/392 I found that some visibility declarations were missing on Linux. Added them in this PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.