### PR TITLE
Fix error output when creating directories

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -466,11 +466,16 @@ bool common::copyDirectory(const std::string &_existingDirname,
 /////////////////////////////////////////////////
 bool common::createDirectories(const std::string &_path)
 {
-  return createDirectories(_path, ignerr);
+  std::ostringstream ss;
+  auto ret = createDirectories(_path, ss);
+  if (!ret)
+    ignerr << ss.str();
+  return ret;
 }
 
 /////////////////////////////////////////////////
-bool common::createDirectories(const std::string &_path, std::ostream &_errorOut)
+bool common::createDirectories(
+  const std::string &_path, std::ostream &_errorOut)
 {
   size_t index = 0;
   while (index < _path.size())


### PR DESCRIPTION
Found when debugging some of the Windows CI failures in `fuel_tools` here: https://github.com/gazebosim/gz-fuel-tools/pull/392

Instead of getting the output routed to gzerr, instead the macro gets expanded incorrectly yielding only:

```
7: [ RUN      ] CmdLine.ModelDownloadUnversioned
7: C:\J\workspace\gz_fuel_tools-pr-win\ws\gz-fuel-tools\src\gz_src_TEST.cc(195): error: Value of: this->stdErrBuffer.str().empty()
7:   Actual: false
7: Expected: true
7: [31m[Err] [C:\J\workspace\gz_fuel_tools-pr-win\ws\gz-common\src\Filesystem.cc:469] [m[31m[Err] [C:\J\workspace\gz_fuel_tools-pr-win\ws\gz-common\src\Filesystem.cc:469] [m[31m[Err] [C:\J\workspace\gz_fuel_tools-pr-win\ws\gz-common\src\Filesystem.cc:469] [m[31m[Err] [C:\J\workspace\gz_fuel_tools-pr-win\ws\gz-common\src\Filesystem.cc:469] [m[31m[Err] [C:\J\workspace\gz_fuel_tools-pr-win\ws\gz-common\src\Filesystem.cc:469] [m
```