### PR TITLE
Use scene name for material name

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -558,7 +558,7 @@ ImagePtr AssimpLoader::Implementation::LoadEmbeddedTexture(
 std::string AssimpLoader::Implementation::GenerateTextureName(
     const aiScene* _scene, aiMaterial* _mat, const std::string& _type) const
 {
-  return ToString(_scene->mRootNode->mName) + "_" + ToString(_mat->GetName()) +
+  return ToString(_scene->mName) + "_" + ToString(_mat->GetName()) +
     "_" + _type;
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
https://github.com/gazebosim/gz-common/pull/563 rebased to `main`.

When importing assimp scenes, the name of the generated texture used the name of the root node as a prefix.
This worked well in simple GLB assets where there is only one node and the name would be its name but the moment a user was to import a scene with more than one node assimp would automatically create a new node and hardcode its name to `ROOT` as shown [here](https://github.com/assimp/assimp/blob/762ad8e9b7d8749c17dedd3e0b9a32b933949e8f/code/AssetLib/glTF2/glTF2Importer.cpp#L1265C55-L1272).

This creates issues when running `gz` with ogre2 since we use the texture name to [share textures](https://github.com/gazebosim/gz-rendering/issues/139) between different assets, so different files would result in textures called `ROOT_[...]` and would cause the wrong texture to be displayed.

The fix is to use the scene name instead of the root node name (which was probably the right implementation in the first place).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.