### PR TITLE
Backwards compatible assimp texture name fix

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -584,7 +584,12 @@ ImagePtr AssimpLoader::Implementation::LoadEmbeddedTexture(
 std::string AssimpLoader::Implementation::GenerateTextureName(
     const aiScene* _scene, aiMaterial* _mat, const std::string& _type) const
 {
-  return ToString(_scene->mRootNode->mName) + "_" + ToString(_mat->GetName()) +
+#ifdef GZ_ASSIMP_PRE_5_2_0
+  auto rootName = _scene->mRootNode->mName;
+#else
+  auto rootName = _scene->mName;
+#endif
+  return ToString(rootName) + "_" + ToString(_mat->GetName()) +
     "_" + _type;
 }
 

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -673,7 +673,13 @@ TEST_F(AssimpLoader, LoadGlTF2BoxWithJPEGTexture)
   EXPECT_EQ(math::Color(0.4f, 0.4f, 0.4f, 1.0f), mat->Ambient());
   EXPECT_EQ(math::Color(1.0f, 1.0f, 1.0f, 1.0f), mat->Diffuse());
   EXPECT_EQ(math::Color(0.0f, 0.0f, 0.0f, 1.0f), mat->Specular());
+  // Assimp 5.2.0 and above uses the scene name for its texture names,
+  // older version use the root node instead.
+#ifdef GZ_ASSIMP_PRE_5_2_0
   EXPECT_EQ("Cube_Material_Diffuse", mat->TextureImage());
+#else
+  EXPECT_EQ("Scene_Material_Diffuse", mat->TextureImage());
+#endif
   EXPECT_NE(nullptr, mat->TextureData());
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Supersedes #564 

## Summary
Apologies for the noise! Hopefully third time is the charm? When working on #564 and #563 I realized that we do have a way to ship changes that depend on the assimp version, by using a define.
This allows us to have the fix in Harmonic (LTS) without being blocked by the fact that `gz-common4` is also shipped in Garden (that is short term support anyway).
If it's desirable I can open a PR targeting main that gets rid of all the `ifdef`s since they are only needed for compatibility with assimp 5.0.x that was last shipped in Ubuntu 20.04.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.