### PR TITLE
Be louder when graphics is missing for geospatial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ configure_file("${PROJECT_SOURCE_DIR}/cppcheck.suppress.in"
                ${PROJECT_BINARY_DIR}/cppcheck.suppress)
 
 gz_configure_build(QUIT_IF_BUILD_ERRORS
-  COMPONENTS av events geospatial graphics io profiler testing)
+  COMPONENTS av events graphics geospatial io profiler testing)
 
 #============================================================================
 # Create package information

--- a/geospatial/src/CMakeLists.txt
+++ b/geospatial/src/CMakeLists.txt
@@ -1,24 +1,27 @@
-gz_get_libsources_and_unittests(sources gtest_sources)
+if (TARGET ${PROJECT_LIBRARY_TARGET_NAME}-graphics)
+  gz_get_libsources_and_unittests(sources gtest_sources)
+  gz_add_component(geospatial
+    SOURCES ${sources}
+    DEPENDS_ON_COMPONENTS graphics
+    GET_TARGET_NAME geospatial_target)
 
-gz_add_component(geospatial
-  SOURCES ${sources}
-  DEPENDS_ON_COMPONENTS graphics
-  GET_TARGET_NAME geospatial_target)
+  target_link_libraries(${geospatial_target}
+    PUBLIC
+      ${PROJECT_LIBRARY_TARGET_NAME}-graphics
+      gz-math${GZ_MATH_VER}::gz-math${GZ_MATH_VER}
+      gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER}
+    PRIVATE
+      ${GDAL_LIBRARY})
 
-target_link_libraries(${geospatial_target}
-  PUBLIC
-    ${PROJECT_LIBRARY_TARGET_NAME}-graphics
-    gz-math${GZ_MATH_VER}::gz-math${GZ_MATH_VER}
-    gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER}
-  PRIVATE
-    ${GDAL_LIBRARY})
+  target_include_directories(${geospatial_target}
+    PRIVATE
+      ${GDAL_INCLUDE_DIR})
 
-target_include_directories(${geospatial_target}
-  PRIVATE
-    ${GDAL_INCLUDE_DIR})
-
-gz_build_tests(TYPE UNIT SOURCES ${gtest_sources}
-  LIB_DEPS
-    ${geospatial_target}
-    gz-common${GZ_COMMON_VER}-testing
-)
+  gz_build_tests(TYPE UNIT SOURCES ${gtest_sources}
+    LIB_DEPS
+      ${geospatial_target}
+      gz-common${GZ_COMMON_VER}-testing
+  )
+else()
+  message(WARNING "Skipping component [geospatial]: Missing component [graphics].\n    ^~~~~ Set SKIP_geospatial=true in cmake to suppress this warning.")
+endif()


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Users building from source could get in a situation where dependencies of the `graphics` component weren't available, so that the component is not created.  In this case, the `geospatial` component still has a hard dependency on the `graphics` component, but it is still attempting to build.

This adds gating logic to prevent the `geospatial` component from building when the `graphics` component isn't build and adds a warning message for the user.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.