### PR TITLE
Clarify GDAL version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ gz_find_package(
 # Find GDAL
 gz_find_package(GDAL VERSION 3.0
   PKGCONFIG gdal
+  PKGCONFIG_VER_COMPARISON >=
   PRIVATE_FOR geospatial
   REQUIRED_BY geospatial)
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The default behavior of pkg-config seems to be an exact version match.

This was discovered when the RPM build process automatically added package dependencies based on the `*.pc` files generated by the project, one of which contained `gdal = 3.0`. This bug can be confirmed on any distro that has a gdal version other than 3.0, such as Ubuntu Jammy:
```
$ pkg-config --cflags gz-common5-geospatial
Package 'gz-common5-geospatial' requires 'gdal = 3.0' but version of gdal is 3.4.1
$ echo $?
1
```

It's interesting that the version comparison behaves differently in the first dependency level (which did not produce an error) than it does in subsequent levels. Perhaps there is a bug in `gz-cmake` as well.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.