### PR TITLE
Fix noise issue that appears in certain image textures

### DIFF
--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -533,7 +533,8 @@ math::Color Image::Pixel(unsigned int _x, unsigned int _y) const
         << _x << " " << _y << "] \n";
       return clr;
     }
-    clr.Set(firgb.rgbRed, firgb.rgbGreen, firgb.rgbBlue);
+    clr.Set(firgb.rgbRed / 255.0f, firgb.rgbGreen / 255.0f,
+            firgb.rgbBlue / 255.0f);
   }
   else
   {
@@ -606,7 +607,8 @@ math::Color Image::MaxColor() const
             << x << " " << y << "] \n";
           continue;
         }
-        clr.Set(firgb.rgbRed, firgb.rgbGreen, firgb.rgbBlue);
+        clr.Set(firgb.rgbRed / 255.0f, firgb.rgbGreen / 255.0f,
+                firgb.rgbBlue / 255.0f);
 
         if (clr.R() + clr.G() + clr.B() > maxClr.R() + maxClr.G() + maxClr.B())
         {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The issue is that if a pixel's color value in 8 bit format is close 1 (out of 255), when assigned to `math::Color`, `math::Color::Clamp` assumes it to be in the floating point range [0.0 - 1.0] instead of 8 bit unsigned range of [0 - 255]. The fix here is to convert colors to floating point at the source instead of relying on `Color::Clamp`.

Reference glTF file: [Damaged helmet](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DamagedHelmet)

### Before
![Screenshot 2024-03-01 17 12 39](https://github.com/gazebosim/gz-common/assets/206116/23caac3b-4c0c-41a2-9d2b-6bb9546bfcd9)

### After
![Screenshot 2024-03-01 17 11 08](https://github.com/gazebosim/gz-common/assets/206116/d3058e6f-4b6d-42d9-a12a-f31043e22230)

## Test it

* Extract [DamagedHelmet.zip](https://github.com/gazebosim/gz-common/files/14466833/DamagedHelmet.zip) and run `gz sim test.sdf` from the same directory



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
