### PR TITLE
Fix compatibility with FFmpeg5.0

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -157,7 +157,11 @@ bool AudioDecoder::Decode(uint8_t **_outBuffer, unsigned int *_outBufferSize)
         // decodedFrame->linesize[0].
         int size = decodedFrame->nb_samples *
           av_get_bytes_per_sample(this->data->codecCtx->sample_fmt) *
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 24, 100)
           this->data->codecCtx->ch_layout.nb_channels;
+#else
+          this->data->codecCtx->channels;
+#endif
         // Resize the audio buffer as necessary
         if (*_outBufferSize + size > maxBufferSize)
         {


### PR DESCRIPTION

 🦟 Bug fix

Fixes #580

## Summary
When I try to build with ffmpeg-5.0, it occurred compile error by comparing patch `[PATCH] Fix compatibility with FFmpeg 5.0 (#325)`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
