### PR TITLE
Add package.xml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,3 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
-  package-xml:
-    runs-on: ubuntu-latest
-    name: package.xml and CMake versions match
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check versions
-        run: |
-          echo "Extract version numbers and compare"
-          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
-          echo "Version in package.xml: ${package_xml_version}"
-          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
-          echo "Version in CMake: ${cmake_version}"
-          [ $package_xml_version = $cmake_version ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,16 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
+  package-xml:
+    runs-on: ubuntu-latest
+    name: package.xml and CMake versions match
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check versions
+        run: |
+          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
+          echo "Version in package.xml: ${package_xml_version}"
+          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
+          echo "Version in CMake: ${cmake_version}"
+          [ package_xml_version = cmake_version ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
           echo "Version in package.xml: ${package_xml_version}"
           cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
           echo "Version in CMake: ${cmake_version}"
-          [ package_xml_version = cmake_version ]
+          [ $package_xml_version = $cmake_version ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check versions
         run: |
+          echo "Extract version numbers and compare"
           package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
           echo "Version in package.xml: ${package_xml_version}"
           cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)

--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -6,15 +6,6 @@ on:
 jobs:
   package-xml:
     runs-on: ubuntu-latest
-    name: package.xml and CMake versions match
+    name: Validate package.xml
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Check versions
-        run: |
-          echo "Extract version numbers and compare"
-          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
-          echo "Version in package.xml: ${package_xml_version}"
-          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
-          echo "Version in CMake: ${cmake_version}"
-          [ $package_xml_version = $cmake_version ]
+      - uses: gazebo-tooling/action-gz-ci/validate_package_xml@jammy

--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -1,0 +1,20 @@
+name: Validate package.xml
+
+on:
+  pull_request:
+
+jobs:
+  package-xml:
+    runs-on: ubuntu-latest
+    name: package.xml and CMake versions match
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check versions
+        run: |
+          echo "Extract version numbers and compare"
+          package_xml_version=$(sed -nE 's/\s*<version>([0-9.]*)<\/version>\s*/\1/p' package.xml)
+          echo "Version in package.xml: ${package_xml_version}"
+          cmake_version=$(sed -nE 's/^project.*VERSION\s*([0-9.]*).*/\1/p' CMakeLists.txt)
+          echo "Version in CMake: ${cmake_version}"
+          [ $package_xml_version = $cmake_version ]

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common5</name>
-  <version>5.5.0</version>
+  <version>5.5.1</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>gz-common5</name>
+  <!--TODO(azeey) Update version. Checking CI-->
+  <version>5.5.0</version>
+  <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
+  <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
+  <license>Apache License 2.0</license>
+  <url type="website">https://github.com/gazebosim/gz-common</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
+
+  <build_depend>gz-cmake3</build_depend>
+
+  <depend>assimp-dev</depend>
+  <depend>ffmpeg-dev</depend>
+  <depend>gz-math7</depend>
+  <depend>gz-utils2</depend>
+  <depend>libfreeimage-dev</depend>
+  <depend>libgdal-dev</depend>
+  <depend>libgts</depend>
+  <depend>tinyxml2</depend>
+  <depend>uuid</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common5</name>
-  <version>5.5.1</version>
+  <version>5.5.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>

--- a/package.xml
+++ b/package.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common5</name>
-  <!--TODO(azeey) Update version. Checking CI-->
-  <version>5.5.0</version>
+  <version>5.5.1</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common5</name>
-  <version>5.5.1</version>
+  <version>5.6.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add `package.xml` based on dependencies found in `.github/ci/packages`. 

This is to test out using vendor packages to provide Gazebo packages to ROS users (see https://github.com/gazebo-tooling/release-tools/issues/1117). 