### PR TITLE
Add new function in MeshManager to merge all submeshes of a mesh into one

### DIFF
--- a/graphics/include/gz/common/MeshManager.hh
+++ b/graphics/include/gz/common/MeshManager.hh
@@ -290,10 +290,16 @@ namespace gz
       /// \param[in] _voxelResolution Voxel resolution to use. Higher value
       /// produces more accurate shapes.
       /// \return A vector of decomposed submeshes.
-      public: std::vector<SubMesh> ConvexDecomposition(
+      public: static std::vector<SubMesh> ConvexDecomposition(
                   const common::SubMesh &_subMesh,
                   std::size_t _maxConvexHulls = 16u,
                   std::size_t _voxelResolution = 200000u);
+
+      /// \brief Merge all submeshes from one mesh into one single submesh.
+      /// \param[in] _mesh Input mesh with submeshes to merge.
+      /// \return A new mesh with the submeshes merged.
+      public: static std::unique_ptr<Mesh> MergeSubMeshes(
+                  const common::Mesh &_mesh);
 
       /// \brief Converts a vector of polylines into a table of vertices and
       /// a list of edges (each made of 2 points from the table of vertices.

--- a/graphics/src/ColladaLoader_TEST.cc
+++ b/graphics/src/ColladaLoader_TEST.cc
@@ -242,8 +242,6 @@ TEST_F(ColladaLoader, TexCoordSets)
   EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(0u, 0u));
   EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(1u, 0u));
   EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(2u, 0u));
-  EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(1u, 0u));
-  EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(2u, 0u));
 
   EXPECT_TRUE(subMeshB->HasTexCoordBySet(0u, 0u));
   EXPECT_TRUE(subMeshB->HasTexCoordBySet(1u, 0u));

--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -19,6 +19,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -1811,7 +1812,7 @@ std::unique_ptr<Mesh> MeshManager::MergeSubMeshes(const Mesh &_mesh)
       }
       else
       {
-        // Set texcoord to zero if it the input submesh does not have that many
+        // Set texcoord to zero if the input submesh does not have that many
         // texcoord sets. Note the texcoord count should be the same as vertex
         // count.
         for (unsigned int k = 0; k < submesh->VertexCount(); ++k)


### PR DESCRIPTION

# 🎉 New feature



## Summary

Add a new static function in MeshManager to merge all submeshes into one. The new function returns a new mesh with a single combined submesh

Note I also made the  `ConvexDecomposition` function that I added in https://github.com/gazebosim/gz-common/pull/585  static as it does not need to be a member function.

## Test it

Added a test that merges two submehes and checked that all its vertices, normals, indices, and texcoords are correct.

Run the `UNIT_MeshManager_TEST`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
