### PR TITLE
Prepare for 5.6.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.5.1)
+project(gz-common5 VERSION 5.6.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,22 @@
 ## Gazebo Common 5.x
 
+## Gazebo Common 5.6.0 (2024-04-23)
+
+1. Clarify units for the DEM classes
+    * [Pull request #595](https://github.com/gazebosim/gz-common/pull/595)
+
+1. Remove pessimizing move
+    * [Pull request #593](https://github.com/gazebosim/gz-common/pull/593)
+
+1. Fix bazel build
+    * [Pull request #592](https://github.com/gazebosim/gz-common/pull/592)
+
+1. Add new function in MeshManager to merge all submeshes of a mesh into one
+    * [Pull request #588](https://github.com/gazebosim/gz-common/pull/588)
+
+1. Adds new function in MeshManager for performing convex decomposition
+    * [Pull request #585](https://github.com/gazebosim/gz-common/pull/585)
+
 ## Gazebo Common 5.5.1 (2024-03-14)
 
 1. Various Bazel adjustments for linting


### PR DESCRIPTION


# 🎈 Release

Preparation for 5.6.0 release.

Comparison to 5.5.1: https://github.com/gazebosim/gz-common/compare/gz-common5_5.5.1...prep_5.6.0


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
