### PR TITLE
Fix deprecation warnings

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -67,7 +67,13 @@ void AudioDecoder::Cleanup()
 {
   // Close the codec
   if (this->data->codecCtx)
+  {
+#if LIBAVFORMAT_VERSION_MAJOR < 59
+    avcodec_close(this->data->codecCtx);
+#else
     avcodec_free_context(&this->data->codecCtx);
+#endif
+  }
 
   // Close the audio file
   if (this->data->formatCtx)

--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -67,7 +67,7 @@ void AudioDecoder::Cleanup()
 {
   // Close the codec
   if (this->data->codecCtx)
-    avcodec_close(this->data->codecCtx);
+    avcodec_free_context(&this->data->codecCtx);
 
   // Close the audio file
   if (this->data->formatCtx)

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -83,7 +83,7 @@ void Video::Cleanup()
   avformat_close_input(&this->dataPtr->formatCtx);
 
   // Close the codec
-  avcodec_close(this->dataPtr->codecCtx);
+  avcodec_free_context(&this->dataPtr->codecCtx);
 
   av_free(this->dataPtr->avFrameDst);
 }

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -83,7 +83,11 @@ void Video::Cleanup()
   avformat_close_input(&this->dataPtr->formatCtx);
 
   // Close the codec
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
   avcodec_free_context(&this->dataPtr->codecCtx);
+#else
+  avcodec_close(this->dataPtr->codecCtx);
+#endif
 
   av_free(this->dataPtr->avFrameDst);
 }

--- a/include/gz/common/EnumIface.hh
+++ b/include/gz/common/EnumIface.hh
@@ -142,7 +142,7 @@ namespace ignition
     /// \verbatim
 #if defined __APPLE__ && defined __clang__
   _Pragma("clang diagnostic push")
-  _Pragma("clang diagnostic ignored -Wdeprecated-declarations")
+  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #endif
     template<typename Enum>
     class EnumIterator

--- a/include/gz/common/EnumIface.hh
+++ b/include/gz/common/EnumIface.hh
@@ -140,6 +140,10 @@ namespace ignition
     ///   std::cout << "Type++ Name[" << myTypeIface.Str(*i) << "]\n";
     /// }
     /// \verbatim
+#if defined __APPLE__ && defined __clang__
+  _Pragma("clang diagnostic push")
+  _Pragma("clang diagnostic ignored -Wdeprecated-declarations")
+#endif
     template<typename Enum>
     class EnumIterator
     : std::iterator<std::bidirectional_iterator_tag, Enum>
@@ -217,6 +221,9 @@ namespace ignition
       /// member value ever used.
       private: Enum c;
     };
+#if defined __APPLE__ && defined __clang__
+  _Pragma("clang diagnostic pop")
+#endif
 
     /// \brief Equality operator
     /// \param[in] _e1 First iterator


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fix deprecation warnings:
* Replace `avcodec_close` with `avcodec_free_context`
* Suppress deprecation of `std::iterator` since we can't change it without breaking ABI. I only did this for macOS, since that's the only platform that emits the warning.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
