### PR TITLE
Generate a more unique texture name for glb embedded textures

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,12 @@
 name: macOS latest
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'ign-common[0-9]'
+      - 'gz-common[0-9]'
+      - 'main'
 
 jobs:
   build:
@@ -8,22 +14,24 @@ jobs:
       PACKAGE: gz-common5
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Homebrew
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
     - run: brew config
+    - run: brew list
 
     # Workaround for https://github.com/actions/setup-python/issues/577
     - name: Clean up python binaries
       run: |
-        rm -f /usr/local/bin/2to3*;
-        rm -f /usr/local/bin/idle3*;
-        rm -f /usr/local/bin/pydoc3*;
-        rm -f /usr/local/bin/python3*;
-        rm -f /usr/local/bin/python3*-config;
-
+        rm -f $(brew --prefix)/bin/2to3*;
+        rm -f $(brew --prefix)/bin/idle3*;
+        rm -f $(brew --prefix)/bin/pydoc3*;
+        rm -f $(brew --prefix)/bin/python3*;
+        rm -f $(brew --prefix)/bin/python3*-config;
     - name: Install base dependencies
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         brew tap osrf/simulation;
         # check for ci_matching_branch
@@ -45,7 +53,7 @@ jobs:
     - run: mkdir build
     - name: cmake
       working-directory: build
-      run: cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+      run: cmake .. -DCMAKE_INSTALL_PREFIX=$(brew --prefix)/Cellar/${PACKAGE}/HEAD
     - run: make
       working-directory: build
     # Run make install before make test so that the package will be available to

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -15,7 +15,9 @@
  *
  */
 
+#include <cstddef>
 #include <queue>
+#include <string>
 #include <unordered_set>
 
 #include "gz/common/graphics/Types.hh"

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -721,9 +721,9 @@ TEST_F(AssimpLoader, LoadGlTF2BoxWithJPEGTexture)
   // Assimp 5.2.0 and above uses the scene name for its texture names,
   // older version use the root node instead.
 #ifdef GZ_ASSIMP_PRE_5_2_0
-  EXPECT_EQ("Cube_Material_Diffuse", mat->TextureImage());
+  EXPECT_EQ("box_texture_jpg_Cube_Material_Diffuse", mat->TextureImage());
 #else
-  EXPECT_EQ("Scene_Material_Diffuse", mat->TextureImage());
+  EXPECT_EQ("box_texture_jpg_Scene_Material_Diffuse", mat->TextureImage());
 #endif
   EXPECT_NE(nullptr, mat->TextureData());
   delete mesh;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

For glb meshes, our assimp loader generates a unique texture name for each embedded texture by prepending the 'scene' or 'root node' name of the glb mesh. However, the generated name may not always be unique. It's possible that different glb files have the same scene and root name. This PR adds the file base name of the mesh to the generated texture name string to make it more unique.

I think this change is similar to the intention in https://github.com/gazebosim/gz-common/pull/565 where it's also trying to make texture names unique.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

