### PR TITLE
SubMesh::RecalculateNormals improvement

### DIFF
--- a/graphics/include/gz/common/SubMesh.hh
+++ b/graphics/include/gz/common/SubMesh.hh
@@ -158,7 +158,7 @@ namespace gz
       public: gz::math::Vector3d Vertex(const unsigned int _index) const;
 
       /// \brief Get the raw vertex pointer. This is unsafe, it is the
-      /// caller's responsability to ensure it's not indexed out of bounds.
+      /// caller's responsibility to ensure it's not indexed out of bounds.
       /// The valid range is [0; VertexCount())
       /// \return Raw vertices
       public: const gz::math::Vector3d* VertexPtr() const;
@@ -224,7 +224,7 @@ namespace gz
       public: int Index(const unsigned int _index) const;
 
       /// \brief Get the raw index pointer. This is unsafe, it is the
-      /// caller's responsability to ensure it's not indexed out of bounds.
+      /// caller's responsibility to ensure it's not indexed out of bounds.
       /// The valid range is [0; IndexCount())
       /// \return Raw indices
       public: const unsigned int* IndexPtr() const;
@@ -416,7 +416,7 @@ namespace gz
       GZ_UTILS_IMPL_PTR(dataPtr)
     };
 
-    /// \brief Vertex to node weighted assignement for skeleton animation
+    /// \brief Vertex to node weighted assignment for skeleton animation
     /// visualization
     class GZ_COMMON_GRAPHICS_VISIBLE NodeAssignment
     {

--- a/graphics/include/gz/common/SubMesh.hh
+++ b/graphics/include/gz/common/SubMesh.hh
@@ -20,7 +20,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include <gz/math/Vector3.hh>
 #include <gz/math/Vector2.hh>

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -644,54 +644,11 @@ void SubMesh::RecalculateNormals()
         this->dataPtr->vertices[this->dataPtr->indices[i+2]];
     gz::math::Vector3d n = gz::math::Vector3d::Normal(v1, v2, v3);
 
-#if 0
-  /*
-  i7-11800H @ Ubuntu22 VM; 2^14 triangles
-    SubMeshTest.NormalsRecalculation (1105 ms)
-    SubMeshTest.NormalsRecalculation (1158 ms)
-    SubMeshTest.NormalsRecalculation (1117 ms)
-    SubMeshTest.NormalsRecalculation (1137 ms)
-    SubMeshTest.NormalsRecalculation (1156 ms)
-  */
-    for (unsigned int j = 0; j < this->dataPtr->vertices.size(); ++j)
-    {
-      gz::math::Vector3d v = this->dataPtr->vertices[j];
-      if (v == v1 || v == v2 || v == v3)
-      {
-        this->dataPtr->normals[j] += n;
-      }
-    }
-#else
-  // same env, ~1ms
-  // FAILS: ASSERT_NE(submesh->Normal(0), submesh->Normal(1));
-    /*this->dataPtr->normals[this->dataPtr->indices[i]] += n;
-    this->dataPtr->normals[this->dataPtr->indices[i+1]] += n;
-    this->dataPtr->normals[this->dataPtr->indices[i+2]] += n;*/
-
-    for (const auto& point : {v1, v2, v3})
+    for (const auto &point : {v1, v2, v3})
       neighbors.Visit(point, [&](unsigned int index)
       {
         this->dataPtr->normals[index] += n;
       });
-
-    //auto& nv1 = neighbors[v1];
-    //nv1.insert(this->dataPtr->indices[i]);
-    /*for (const auto index: neighbors[v1])
-      this->dataPtr->normals[index] += n;*/
-
-    //neighbors[v2].insert(this->dataPtr->indices[i+1]);
-    //auto& nv2 = neighbors[v2];
-    //nv2.insert(this->dataPtr->indices[i+1]);
-    /*for (const auto index: neighbors[v2])
-      this->dataPtr->normals[index] += n;*/
-
-    //neighbors[v3].insert(this->dataPtr->indices[i+2]);
-    //auto& nv3 = neighbors[v3];
-    //nv3.insert(this->dataPtr->indices[i+2]);
-    /*for (const auto index: neighbors[v3])
-      this->dataPtr->normals[index] += n;*/
-
-#endif
   }
 
   // Normalize the results

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <limits>
 #include <map>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -578,7 +577,8 @@ namespace {
 // Simple way to find neighbors by grouping all vertices
 // by X coordinate with (ordered) map. KD-tree maybe better
 // but not sure about construction overhead
-struct Neighbors {
+struct Neighbors
+{
   Neighbors(const std::vector<unsigned int> &_indices,
             const std::vector<gz::math::Vector3d> &_vertices)
     : vertices(_vertices)
@@ -591,7 +591,7 @@ struct Neighbors {
   }
 
   template<typename Visitor>
-  void Visit(const gz::math::Vector3d &_point, Visitor _v)
+  void Visit(const gz::math::Vector3d &_point, Visitor _v) const
   {
     auto it = this->neighbors.find(_point.X());
     // find smaller acceptable value
@@ -645,7 +645,7 @@ void SubMesh::RecalculateNormals()
     gz::math::Vector3d n = gz::math::Vector3d::Normal(v1, v2, v3);
 
     for (const auto &point : {v1, v2, v3})
-      neighbors.Visit(point, [&](unsigned int index)
+      neighbors.Visit(point, [&](const unsigned int index)
       {
         this->dataPtr->normals[index] += n;
       });

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -598,9 +598,30 @@ void SubMesh::RecalculateNormals()
         this->dataPtr->vertices[this->dataPtr->indices[i+2]];
     gz::math::Vector3d n = gz::math::Vector3d::Normal(v1, v2, v3);
 
+#if 1
+  /*
+  i7-11800H @ Ubuntu22 VM; 2^14 triangles
+    SubMeshTest.NormalsRecalculation (1105 ms)
+    SubMeshTest.NormalsRecalculation (1158 ms)
+    SubMeshTest.NormalsRecalculation (1117 ms)
+    SubMeshTest.NormalsRecalculation (1137 ms)
+    SubMeshTest.NormalsRecalculation (1156 ms)
+  */
+    for (unsigned int j = 0; j < this->dataPtr->vertices.size(); ++j)
+    {
+      gz::math::Vector3d v = this->dataPtr->vertices[j];
+      if (v == v1 || v == v2 || v == v3)
+      {
+        this->dataPtr->normals[j] += n;
+      }
+    }
+#else
+  // same env, ~1ms
+  // FAILS: ASSERT_NE(submesh->Normal(0), submesh->Normal(1));
     this->dataPtr->normals[this->dataPtr->indices[i]] += n;
     this->dataPtr->normals[this->dataPtr->indices[i+1]] += n;
     this->dataPtr->normals[this->dataPtr->indices[i+2]] += n;
+#endif
   }
 
   // Normalize the results

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -603,7 +603,8 @@ struct Neighbors
         break;
       it = prev;
     }
-    while (gz::math::equal(it->first, _point.X()))
+    while (it != this->neighbors.end()
+           && gz::math::equal(it->first, _point.X()))
     {
       for (const auto index : it->second)
         if (this->vertices[index] == _point)

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -576,7 +576,8 @@ void SubMesh::FillArrays(double **_vertArr, int **_indArr) const
 //////////////////////////////////////////////////
 void SubMesh::RecalculateNormals()
 {
-  if (this->dataPtr->normals.size() < 3u)
+  if (this->dataPtr->indices.size() == 0
+      || this->dataPtr->indices.size() % 3u != 0)
     return;
 
   // Reset all the normals
@@ -597,14 +598,9 @@ void SubMesh::RecalculateNormals()
         this->dataPtr->vertices[this->dataPtr->indices[i+2]];
     gz::math::Vector3d n = gz::math::Vector3d::Normal(v1, v2, v3);
 
-    for (unsigned int j = 0; j < this->dataPtr->vertices.size(); ++j)
-    {
-      gz::math::Vector3d v = this->dataPtr->vertices[j];
-      if (v == v1 || v == v2 || v == v3)
-      {
-        this->dataPtr->normals[j] += n;
-      }
-    }
+    this->dataPtr->normals[this->dataPtr->indices[i]] += n;
+    this->dataPtr->normals[this->dataPtr->indices[i+1]] += n;
+    this->dataPtr->normals[this->dataPtr->indices[i+2]] += n;
   }
 
   // Normalize the results

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -575,7 +575,7 @@ void SubMesh::FillArrays(double **_vertArr, int **_indArr) const
 }
 
 namespace {
-// Simple way to finding neighbors by grouping all vertexes
+// Simple way to find neighbors by grouping all vertices
 // by X coordinate with (ordered) map. KD-tree maybe better
 // but not sure about construction overhead
 struct Neighbors {

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -585,3 +585,27 @@ TEST_F(SubMeshTest, Volume)
   boxSub.AddIndex(1);
   EXPECT_DOUBLE_EQ(0.0, boxSub.Volume());
 }
+
+/////////////////////////////////////////////////
+TEST_F(SubMeshTest, NormalsRecalculation)
+{
+  auto submesh = std::make_shared<common::SubMesh>();
+  submesh->SetPrimitiveType(common::SubMesh::TRIANGLES);
+
+  constexpr unsigned int elements = 65536/4;
+  for (unsigned int i = 0; i < elements; ++i) {
+    submesh->AddVertex(i, i, i);
+    submesh->AddVertex(i+1, i+1, i+1);
+    submesh->AddVertex(i, i, -i);
+
+    submesh->AddIndex(3*i);
+    submesh->AddIndex(3*i+1);
+    submesh->AddIndex(3*i+2);
+  }
+
+  ASSERT_EQ(submesh->IndexCount() % 3, 0u);
+  submesh->RecalculateNormals();
+  ASSERT_EQ(submesh->NormalCount(), submesh->VertexCount());
+  // Same triangle, but different normals
+  ASSERT_NE(submesh->Normal(0), submesh->Normal(1));
+}

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -592,9 +592,13 @@ TEST_F(SubMeshTest, NormalsRecalculation)
   auto submesh = std::make_shared<common::SubMesh>();
   submesh->SetPrimitiveType(common::SubMesh::TRIANGLES);
 
-  constexpr unsigned int elements = 65536/4;
+  constexpr unsigned int elements = 16384;
   for (unsigned int i = 0; i < elements; ++i) {
-    submesh->AddVertex(i, i, i);
+    // sub to X less than _epsilon from even elements
+    // expect that the 2nd vertex should be matched with
+    // the 1st of next triangle
+    const auto jitter = i % 2 ? 1e-7 : 0.0;
+    submesh->AddVertex(i-jitter, i, i);
     submesh->AddVertex(i+1, i+1, i+1);
     submesh->AddVertex(i, i, -i);
 
@@ -607,5 +611,6 @@ TEST_F(SubMeshTest, NormalsRecalculation)
   submesh->RecalculateNormals();
   ASSERT_EQ(submesh->NormalCount(), submesh->VertexCount());
   // Same triangle, but different normals
+  // because of neighbour vertex
   ASSERT_NE(submesh->Normal(0), submesh->Normal(1));
 }

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -600,7 +600,7 @@ TEST_F(SubMeshTest, NormalsRecalculation)
     const auto jitter = i % 2 ? 1e-7 : 0.0;
     submesh->AddVertex(i-jitter, i, i);
     submesh->AddVertex(i+1, i+1, i+1);
-    submesh->AddVertex(i, i, -i);
+    submesh->AddVertex(i, i, -static_cast<double>(i));
 
     submesh->AddIndex(3*i);
     submesh->AddIndex(3*i+1);

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -592,9 +592,9 @@ TEST_F(SubMeshTest, NormalsRecalculation)
   auto submesh = std::make_shared<common::SubMesh>();
   submesh->SetPrimitiveType(common::SubMesh::TRIANGLES);
 
-  constexpr unsigned int elements = 16384;
-  for (unsigned int i = 0; i < elements; ++i) {
-    // sub to X less than _epsilon from even elements
+  constexpr unsigned int triangles = 16384;
+  for (unsigned int i = 0; i < triangles; ++i) {
+    // sub to X less than _epsilon from even triangles
     // expect that the 2nd vertex should be matched with
     // the 1st of next triangle
     const auto jitter = i % 2 ? 1e-7 : 0.0;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #N/A

## Summary
Previous version of `RecalculateNormals` member function has a O(n^2) complexity because inner loop where we are looking for normal elements. But we already know indexes of this elements. So we can get rid of inner loop.
And seems we should check `indices.size() < 3u || indices.size() % 3u != 0` due to if it will be 4, main loop will start and on second iteration it will start reading out of array.
Also seems condition in the begin should check amount of indexes/vector, but not normals, due to we are resizing it later.
Maybe this function also should have a check of `enum PrimitiveType` of data, seems attempt to call it for `POINTS` and `LINES` is not legit (for rest 4 types maybe it's ok, not sure)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
