### PR TITLE
Fix data race issue in VHACD found by TSAN

### DIFF
--- a/graphics/src/VHACD/VHACD.h
+++ b/graphics/src/VHACD/VHACD.h
@@ -113,6 +113,12 @@
 #include <stdint.h>
 #include <functional>
 
+// Local modification done by @iche033
+// The m_voxelHullCount variable type is changed from
+// uint32_t to std::atomic<uint32_t>
+// to fix data race issue picked up by TSAN
+#include <atomic>
+
 #include <vector>
 #include <array>
 #include <cmath>
@@ -5965,12 +5971,12 @@ public:
     std::unordered_map<uint32_t, uint32_t>      m_voxelIndexMap; // Maps from a voxel coordinate space into a vertex index space
     std::vector<VHACD::Vertex>                  m_vertices;
     std::vector<VHACD::Triangle>                m_indices;
-    static uint32_t                             m_voxelHullCount;
+    static std::atomic<uint32_t>                m_voxelHullCount;
     IVHACD::Parameters                          m_params;
     VHACDCallbacks*                             m_callbacks{ nullptr };
 };
 
-uint32_t VoxelHull::m_voxelHullCount = 0;
+std::atomic<uint32_t> VoxelHull::m_voxelHullCount = 0;
 
 VoxelHull::VoxelHull(const VoxelHull& parent,
                      SplitAxis axis,


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

VHACD can be run [multi-threaded](https://github.com/gazebosim/gz-common/blob/27f7017c5c1b1fd2ba9c603e92b694f98417175d/graphics/src/MeshManager.cc#L1704), and TSAN picked up a data race issue:

```
SUMMARY: ThreadSanitizer: data race <path_to_gz-common>/graphics/src/VHACD/VHACD.h:5985:15 in VHACD::VoxelHull::VoxelHull(VHACD::VoxelHull const&, VHACD::SplitAxis, unsigned int)
```

Changing to an atomic type fixes the problem.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

