### PR TITLE
Enable 24.04 CI, require cmake 3.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,18 @@ jobs:
     name: Ubuntu Jammy CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
           codecov-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(gz-common-examples)
 

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -57,7 +57,7 @@ Update your CMakeLists.txt to the following. Note that the profiler must be
 enabled at compile time in order to function.
 
 ```{.cpp}
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 # Find the gz-common library
 find_package(gz-common6 QUIET REQUIRED COMPONENTS profiler)


### PR DESCRIPTION
# 🎉 New feature

Part of gazebosim/gz-cmake#350.

## Summary

This adds a GitHub workflow using Noble and increases our minimum required cmake version to 3.22.1 since we are already requiring that in gz-cmake4.

## Test it

Check CI results.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
