### PR TITLE
Remove debug logging introduced accidentally in PR review

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -513,10 +513,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     pbr.SetRoughness(value);
   }
 #endif
-  std::cout << "Diffuse: " << mat->Diffuse() << std::endl;
-  std::cout << "Specular: " << mat->Specular() << std::endl;
-  std::cout << "Roughness: " << pbr.Roughness() << std::endl;
-  std::cout << "Metalness: " << pbr.Metalness() << std::endl;
   mat->SetPbrMaterial(pbr);
   return mat;
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
These debugging lines were added in https://github.com/gazebosim/gz-common/pull/597 when I fixed a small typo as part of a PR review.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.