### PR TITLE
Test that Delaunay triangles wind clockwise

### DIFF
--- a/graphics/src/DelaunayTriangulation_TEST.cc
+++ b/graphics/src/DelaunayTriangulation_TEST.cc
@@ -71,4 +71,25 @@ TEST_F(DelaunayTriangulation, DelaunayTriangulation)
 
   // there should be 8 triangles.
   EXPECT_EQ(subMesh.IndexCount() / 3u, 8u);
+
+  // verify that triangles have clockwise winding
+  for (int t = 0; t < subMesh.IndexCount() / 3u; ++t)
+  {
+    int vertexIndex1 = subMesh.Index(t*3 + 0);
+    int vertexIndex2 = subMesh.Index(t*3 + 1);
+    int vertexIndex3 = subMesh.Index(t*3 + 2);
+    // compute displacement from vertex 1 to 2
+    auto displacement12 =
+        subMesh.Vertex(vertexIndex2) - subMesh.Vertex(vertexIndex1);
+    // compute displacement from vertex 2 to 3
+    auto displacement23 =
+        subMesh.Vertex(vertexIndex3) - subMesh.Vertex(vertexIndex2);
+    // compute cross product (v2-v1) x (v3 - v2)
+    auto crossProduct_12_23 = displacement12.Cross(displacement23);
+    // X and Y components should be zero
+    EXPECT_DOUBLE_EQ(0.0, crossProduct_12_23.X());
+    EXPECT_DOUBLE_EQ(0.0, crossProduct_12_23.Y());
+    // Z component should be negative for a clockwise winding
+    EXPECT_LT(crossProduct_12_23.Z(), 0.0);
+  }
 }


### PR DESCRIPTION
# 🦟 Bug fix

Adds a test for #623 

## Summary

PR #623 ensures that Delaunay triangles have clockwise winding; this confirms that with a test using a cross product `(v2 - v1) x (v3 - v2)`. Since Z = 0 for all the vertices in this test, the cross product should have a negative Z component for clockwise winding (right-hand rule is positive for counter-clockwise, negative for clockwise).

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
