### PR TITLE
Remove flushes and fix tests

### DIFF
--- a/include/gz/common/Console.hh
+++ b/include/gz/common/Console.hh
@@ -42,8 +42,6 @@ namespace gz
       /// \param[in] _file Filename.
       /// \param[in] _line Line number.
       /// \param[in] _logLevel Log level.
-      /// \param[in] _fileInitialize True if the file logger needs to be
-      /// initialized or false otherwise.
       public: LogMessage(const char *_file,
                          int _line,
                          spdlog::level::level_enum _logLevel);

--- a/include/gz/common/Console.hh
+++ b/include/gz/common/Console.hh
@@ -46,8 +46,7 @@ namespace gz
       /// initialized or false otherwise.
       public: LogMessage(const char *_file,
                          int _line,
-                         spdlog::level::level_enum _logLevel,
-                         bool _fileInitialize = false);
+                         spdlog::level::level_enum _logLevel);
 
       /// \brief Destructor.
       public: ~LogMessage();
@@ -80,7 +79,7 @@ namespace gz
 
     /// \brief Output a message to a log file.
     #define gzlog gz::common::LogMessage( \
-      __FILE__, __LINE__, spdlog::level::err, true).stream()
+      __FILE__, __LINE__, spdlog::level::err).stream()
 
     /// \brief Output a message.
     #define gzmsg gz::common::LogMessage( \

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -37,12 +37,12 @@ using namespace common;
 
 /////////////////////////////////////////////////
 LogMessage::LogMessage(const char *_file, int _line,
-  spdlog::level::level_enum _logLevel, bool _fileInitialize)
+  spdlog::level::level_enum _logLevel)
   : severity(_logLevel),
     sourceLocation(_file, _line, "")
 {
   // Use default initialization if needed.
-  if (_fileInitialize && !Console::initialized)
+  if (!Console::initialized)
     Console::Init(".gz", "auto_default.log");
 }
 
@@ -108,8 +108,6 @@ bool Console::Init(const std::string &_directory, const std::string &_filename)
   logPath = joinPaths(logPath, _filename);
 
   Console::Root().SetLogDestination(logPath.c_str());
-  Console::Root().RawLogger().log(spdlog::level::info,
-    "Setting log file output destination to {}", logPath.c_str());
   Console::initialized = true;
 
   return true;

--- a/src/Console_TEST.cc
+++ b/src/Console_TEST.cc
@@ -203,8 +203,6 @@ TEST_F(Console_TEST, ColorWarnSlashN)
     gzwarn << logString << " _n__ " << i << '\n';
   }
 
-  common::Console::Root().RawLogger().flush();
-
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)
@@ -234,8 +232,6 @@ TEST_F(Console_TEST, ColorWarnStdEndl)
   {
     gzwarn << logString << " endl " << i << std::endl;
   }
-
-  common::Console::Root().RawLogger().flush();
 
   std::string logContent = GetLogContent(logPath);
 
@@ -267,8 +263,6 @@ TEST_F(Console_TEST, ColorDbgSlashN)
     gzdbg << logString << " _n__ " << i << '\n';
   }
 
-  common::Console::Root().RawLogger().flush();
-
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)
@@ -298,8 +292,6 @@ TEST_F(Console_TEST, ColorDbgStdEndl)
   {
     gzdbg << logString << " endl " << i << std::endl;
   }
-
-  common::Console::Root().RawLogger().flush();
 
   std::string logContent = GetLogContent(logPath);
 
@@ -331,8 +323,6 @@ TEST_F(Console_TEST, ColorMsgSlashN)
     gzmsg << logString << " _n__ " << i << '\n';
   }
 
-  common::Console::Root().RawLogger().flush();
-
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)
@@ -362,8 +352,6 @@ TEST_F(Console_TEST, ColorMsgStdEndl)
   {
     gzmsg << logString << " endl " << i << std::endl;
   }
-
-  common::Console::Root().RawLogger().flush();
 
   std::string logContent = GetLogContent(logPath);
 
@@ -395,8 +383,6 @@ TEST_F(Console_TEST, ColorErrSlashN)
     gzerr << logString << " _n__ " << i << '\n';
   }
 
-  common::Console::Root().RawLogger().flush();
-
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)
@@ -427,8 +413,6 @@ TEST_F(Console_TEST, ColorErrStdEndl)
     gzerr << logString << " endl " << i << std::endl;
   }
 
-  common::Console::Root().RawLogger().flush();
-
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)
@@ -455,8 +439,6 @@ TEST_F(Console_TEST, ColorMsg)
   std::string logString = "this is a msg test";
 
   gzmsg << logString << std::endl;
-
-  common::Console::Root().RawLogger().flush();
 
   std::string logContent = GetLogContent(logPath);
 
@@ -526,8 +508,6 @@ TEST_F(Console_TEST, Prefix)
   gzwarn << "warning" << std::endl;
   gzmsg << "message" << std::endl;
   gzdbg << "debug" << std::endl;
-
-  common::Console::Root().RawLogger().flush();
 
   // Get the logged content
   std::string logContent = GetLogContent(logPath);


### PR DESCRIPTION
With https://github.com/gazebosim/gz-utils/pull/142, it's no longer necessary to flush manually. This removes the need for `_fileInitialize` and fixes the behavior of `auto_default.log`.