### PR TITLE
Prepare for gz-common6.0.0~pre2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,12 @@
 
 1. **Baseline:** this includes all changes from 5.6.0 and earlier.
 
+1. Experimenting with spdlog
+    * [Pull request #615](https://github.com/gazebosim/gz-common/pull/615)
+
+1. Update Changelog, README and prepare for gz-common6.0.0~pre1 release
+    * [Pull request #626](https://github.com/gazebosim/gz-common/pull/626)
+
 1. Use self-pipe trick to implement signal handlers
     * [Pull request #618](https://github.com/gazebosim/gz-common/pull/618)
 


### PR DESCRIPTION


# 🎈 Release

Preparation for 6.0.0pre2 release.

Comparison to 6.0.0pre1: https://github.com/gazebosim/gz-common/compare/gz-common6_6.0.0-pre1...prep_6.0.0pre2


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
