### PR TITLE
Fix loading lightmaps from gltf / glb meshes

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -16,9 +16,11 @@
  */
 
 #include <cstddef>
+#include <memory>
 #include <queue>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "gz/common/graphics/Types.hh"
 #include "gz/common/AssimpLoader.hh"


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Fix loading gltf / glb mesh files with lightmaps. Needed by the Ionic demo world.

Currently the lightmap is ignored if there's a combined roughness + metalness texture. This PR fixes the problem by loading the lightmap (ambient occlusion data) from the roughness + metalness texture.

Tested with a few [gltf sample models](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0) (water bottle, barramundi fish, damaged helmet)

Here are screenshots of the [BarramundiFish](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/BarramundiFish) before (left) and after (right) the change. I removed the albedo map to better visualize the effect of the lightmap:

<img width="251" alt="barramundi_no_lightmap" src="https://github.com/user-attachments/assets/ba0262d2-30f0-493d-b160-ba51eef35c8d">

<img width="244" alt="barramundi_lightmap" src="https://github.com/user-attachments/assets/44f530ae-7cf3-4e7b-8aa8-7c9d3e58c0ad">





## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
