### PR TITLE
Fix severity level of gzlog

### DIFF
--- a/graphics/src/ColladaLoader_TEST.cc
+++ b/graphics/src/ColladaLoader_TEST.cc
@@ -112,6 +112,7 @@ TEST_F(ColladaLoader, LoadZeroCount)
       common::testing::TestFile("data", "zero_count.dae"));
   ASSERT_TRUE(mesh);
 #ifndef _WIN32
+  common::Console::Root().RawLogger().flush();
   std::string log = LogContent();
 
   // Expect no errors about missing values

--- a/include/gz/common/Console.hh
+++ b/include/gz/common/Console.hh
@@ -77,7 +77,7 @@ namespace gz
 
     /// \brief Output a message to a log file.
     #define gzlog gz::common::LogMessage( \
-      __FILE__, __LINE__, spdlog::level::err).stream()
+      __FILE__, __LINE__, spdlog::level::trace).stream()
 
     /// \brief Output a message.
     #define gzmsg gz::common::LogMessage( \

--- a/src/Console_TEST.cc
+++ b/src/Console_TEST.cc
@@ -82,6 +82,7 @@ TEST_F(Console_TEST, NoInitAndLog)
   // Get the absolute log file path
   std::string logPath = ".gz/auto_default.log";
 
+  common::Console::Root().RawLogger().flush();
   // Expect to find the string in the log file
   EXPECT_TRUE(GetLogContent(logPath).find(logString) != std::string::npos);
 
@@ -118,6 +119,7 @@ TEST_F(Console_TEST, InitAndLog)
   // Get the absolute log file path
   std::string logPath = common::joinPaths(path, "test.log");
 
+  common::Console::Root().RawLogger().flush();
   // Expect to find the string in the log file
   EXPECT_TRUE(GetLogContent(logPath).find(logString) != std::string::npos);
 
@@ -149,6 +151,7 @@ TEST_F(Console_TEST, LogSlashN)
     gzlog << logString << " _n__ " << i << '\n';
   }
 
+  common::Console::Root().RawLogger().flush();
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)
@@ -179,6 +182,7 @@ TEST_F(Console_TEST, LogStdEndl)
     gzlog << logString << " endl " << i << std::endl;
   }
 
+  common::Console::Root().RawLogger().flush();
   std::string logContent = GetLogContent(logPath);
 
   for (int i = 0; i < g_messageRepeat; ++i)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #632 

## Summary
The severity level of `gzlog` was incorrectly set to `err`. Changing this to `trace` solves two problems:
1. The log message is now a lot less alarming 
2. When running `gz sim -v4`, this message is not shown on the console. It will only be logged to file. It does show up on the console if you run with `-v5`. 
 
The second point is technically a behavior change since in Harmonic, regardless of the verbosity level, `gzlog` would never show up on the console. However, duplicating that behavior with the new Console implementation proved to be very complicated. So, I propose we change the meaning of `gzlog` to be equivalent to `gztrace`.

---

**Note**
We'll have to make new prereleases of all downstream libraries for this fix to propagate. I vote we just wait for the stable release.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.