### PR TITLE
docs/hw-encoding: Add a note about the conda-distributed ffmpeg on windows

### DIFF
--- a/tutorials/hw-encoding.md
+++ b/tutorials/hw-encoding.md
@@ -271,6 +271,14 @@ Just give them a try and dig deeper in the configuration if something is wrong.
 
 # Caveats
 
+## FFMpeg on Windows via Conda
+
+The current distribution of FFMpeg via Conda for Windows does not include the h264_qsv
+encoder. It only has h264_nvenc. This means that using Intel GPUs for HW acceleration is
+not possible out of the box. A possible solution would be to build a custom build of
+ffmpeg in the workspace with gz-common. Pull requests with the relevant tutorial are
+welcome.
+
 ## NVEnc per-machine limit
 
 If you have a multi-GPU station with desktop-class (not server-class) GPUs, you will


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The ffmpeg distributed via conda only has these encoders on win64:

```
(D:\programming\gz9-ws\conda) D:\programming\gz9-ws\gz-ws>ffmpeg -hide_banner -encoders | grep 264
 V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
 V....D libx264rgb           libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
 V....D libopenh264          OpenH264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
 V....D h264_mf              H264 via MediaFoundation (codec h264)
 V....D h264_nvenc           NVIDIA NVENC H.264 encoder (codec h264)
```

I've added an explicit notice that Windows users with Intel GPUs won't have HW acceleration available out of the box.

If somebody knows about an easy way to provide a custom ffmpeg build with h264_qsv, it would be good to add it to the general install instructions.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.