### PR TITLE
Prepare for 6.0.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,25 @@
 ## Gazebo Common 6.x
 
-## Gazebo Common 6.0.0 (2024-09-XX)
+## Gazebo Common 6.0.0 (2024-09-25)
 
 1. **Baseline:** this includes all changes from 5.6.0 and earlier.
 
-1. Experimenting with spdlog
+1. Add a note about the conda-distributed ffmpeg on windows
+    * [Pull request #640](https://github.com/gazebosim/gz-common/pull/640)
+
+1. Fix table of content
+    * [Pull request #639](https://github.com/gazebosim/gz-common/pull/639)
+
+1. Fix severity level of gzlog
+    * [Pull request #635](https://github.com/gazebosim/gz-common/pull/635)
+
+1. Fix loading lightmaps from gltf / glb meshes
+    * [Pull request #630](https://github.com/gazebosim/gz-common/pull/630)
+
+1. Fix AssimpLoader collada texture coordinates
+    * [Pull request #634](https://github.com/gazebosim/gz-common/pull/634)
+
+1. Implement console logging using `spdlog`
     * [Pull request #615](https://github.com/gazebosim/gz-common/pull/615)
 
 1. Update Changelog, README and prepare for gz-common6.0.0~pre1 release


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.0.0 release.

Comparison to 6.0.0-pre2: https://github.com/gazebosim/gz-common/compare/gz-common6_6.0.0-pre2...gz-common6

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.