### PR TITLE
Remove gts references from documentation

### DIFF
--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -71,7 +71,6 @@ Gazebo Common requires:
 The Graphics component requires:
 
   * [FreeImage](http://freeimage.sourceforge.net/)
-  * [GTS](http://gts.sourceforge.net/).
 
 The AV component requires:
 
@@ -98,7 +97,7 @@ conda activate gz-ws
 
 Install prerequisites:
 ```
-conda install freeimage gdal gts glib dlfcn-win32 ffmpeg --channel conda-forge
+conda install freeimage gdal glib dlfcn-win32 ffmpeg --channel conda-forge
 ```
 
 Install Gazebo dependencies:


### PR DESCRIPTION
# 🦟 Bug fix

Remove some references to GTS library, leftover from https://github.com/gazebosim/gz-common/pull/617 .


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
