### PR TITLE
Include math::Angle since it is used here

### DIFF
--- a/graphics/src/SVGLoader.cc
+++ b/graphics/src/SVGLoader.cc
@@ -23,9 +23,10 @@
 
 #include "tinyxml2.h"
 
+#include "gz/math/Angle.hh"
+
 #include "gz/common/Console.hh"
 #include "gz/common/Util.hh"
-
 #include "gz/common/SVGLoader.hh"
 
 using namespace gz;


### PR DESCRIPTION
Transitive header wasn't being accounted for and this got broken by https://github.com/gazebosim/gz-math/pull/589