### PR TITLE
Remove Conda Windows warnings

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -40,7 +40,7 @@
 #include <assimp/Importer.hpp>      // C++ importer interface
 #include <assimp/postprocess.h>     // Post processing flags
 #include <assimp/scene.h>           // Output data structure
-#include <assimp/material.h> 
+#include <assimp/material.h>
 
 // Disable warning for converting double to unsigned char
 #ifdef _WIN32

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -40,6 +40,7 @@
 #include <assimp/Importer.hpp>      // C++ importer interface
 #include <assimp/postprocess.h>     // Post processing flags
 #include <assimp/scene.h>           // Output data structure
+#include <assimp/material.h> 
 
 // Disable warning for converting double to unsigned char
 #ifdef _WIN32

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -684,7 +684,7 @@ TEST_F(AssimpLoader, LoadGlTF2BoxTransmission)
   const common::MaterialPtr mat = mesh->MaterialByIndex(0u);
   ASSERT_TRUE(mat.get());
   // transmission currently modeled as transparency
-  EXPECT_FLOAT_EQ(0.1, mat->Transparency());
+  EXPECT_DOUBLE_EQ(0.1f, mat->Transparency());
   delete mesh;
 #endif
 }
@@ -791,7 +791,7 @@ TEST_F(AssimpLoader, LoadGlbPbrAsset)
   EXPECT_NE(pbr->RoughnessMapData(), nullptr);
   // Check pixel values to test metallicroughness texture splitting
   EXPECT_FLOAT_EQ(pbr->MetalnessMapData()->Pixel(256, 256).R(), 0.0);
-  EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(), 124.0 / 255.0);
+  EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(), 124.0f / 255.0f);
 
   // Bug in assimp 5.0.x that doesn't parse coordinate sets properly
   // \todo(iche033) Lightmaps are disabled for glb meshes

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -684,7 +684,7 @@ TEST_F(AssimpLoader, LoadGlTF2BoxTransmission)
   const common::MaterialPtr mat = mesh->MaterialByIndex(0u);
   ASSERT_TRUE(mat.get());
   // transmission currently modeled as transparency
-  EXPECT_DOUBLE_EQ(0.1f, mat->Transparency());
+  EXPECT_DOUBLE_EQ(0.1, mat->Transparency());
   delete mesh;
 #endif
 }

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -684,7 +684,7 @@ TEST_F(AssimpLoader, LoadGlTF2BoxTransmission)
   const common::MaterialPtr mat = mesh->MaterialByIndex(0u);
   ASSERT_TRUE(mat.get());
   // transmission currently modeled as transparency
-  EXPECT_DOUBLE_EQ(0.1, mat->Transparency());
+  EXPECT_FLOAT_EQ(0.1f, mat->Transparency());
   delete mesh;
 #endif
 }


### PR DESCRIPTION
A missing header and a couple of tweaks to make the MSVC compiler happy.

Complaining: https://build.osrfoundation.org/view/conda/job/gz_common-5-cwin/1/msbuild/

Fixed: https://build.osrfoundation.org/job/_test_gz_common-pr-cwin/8/