### PR TITLE
Deprecate env() with two parameters

### DIFF
--- a/include/gz/common/Util.hh
+++ b/include/gz/common/Util.hh
@@ -209,16 +209,6 @@ namespace gz
     }
 
     /// \brief Find the environment variable '_name' and return its value.
-    ///
-    /// \TODO(mjcarroll): Deprecate and remove in tick-tock.
-    ///
-    /// \param[in] _name Name of the environment variable.
-    /// \param[out] _value Value if the variable was found.
-    /// \return True if the variable was found or false otherwise.
-    bool GZ_COMMON_VISIBLE env(
-        const std::string &_name, std::string &_value);
-
-    /// \brief Find the environment variable '_name' and return its value.
     /// \param[in] _name Name of the environment variable.
     /// \param[out] _value Value if the variable was found.
     /// \param[in] _allowEmpty Allow set-but-empty variables.
@@ -226,7 +216,7 @@ namespace gz
     /// \return True if the variable was found or false otherwise.
     bool GZ_COMMON_VISIBLE env(
         const std::string &_name, std::string &_value,
-        bool _allowEmpty);
+        bool _allowEmpty = false);
 
     /// \brief Set the environment variable '_name'.
     ///

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -350,12 +350,6 @@ common::SystemPaths *common::systemPaths()
 }
 
 /////////////////////////////////////////////////
-bool common::env(const std::string &_name, std::string &_value)
-{
-  return env(_name, _value, false);
-}
-
-/////////////////////////////////////////////////
 bool common::env(const std::string &_name,
                            std::string &_value,
                            bool _allowEmpty)


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

As part of the Ionic tick-tock process, we're updating this function in favor of the version with three arguments. We also make the three version function works with two arguments only.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.