### PR TITLE
Check normal presence before trying to read asMesh normals

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -700,6 +700,9 @@ SubMesh AssimpLoader::Implementation::CreateSubMesh(
     subMesh.AddIndex(face.mIndices[2]);
   }
   subMesh.SetMaterialIndex(_assimpMesh->mMaterialIndex);
+  if (subMesh.NormalCount() == 0u){
+    subMesh.RecalculateNormals();
+  }
   return subMesh;
 }
 

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -667,18 +667,20 @@ SubMesh AssimpLoader::Implementation::CreateSubMesh(
   {
     // Add the vertex
     math::Vector3d vertex;
-    math::Vector3d normal;
     vertex.X(_assimpMesh->mVertices[vertexIdx].x);
     vertex.Y(_assimpMesh->mVertices[vertexIdx].y);
     vertex.Z(_assimpMesh->mVertices[vertexIdx].z);
-    normal.X(_assimpMesh->mNormals[vertexIdx].x);
-    normal.Y(_assimpMesh->mNormals[vertexIdx].y);
-    normal.Z(_assimpMesh->mNormals[vertexIdx].z);
     vertex = _transform * vertex;
-    normal = rot * normal;
-    normal.Normalize();
     subMesh.AddVertex(vertex);
-    subMesh.AddNormal(normal);
+    if (_assimpMesh->HasNormals()) {
+      math::Vector3d normal;
+      normal.X(_assimpMesh->mNormals[vertexIdx].x);
+      normal.Y(_assimpMesh->mNormals[vertexIdx].y);
+      normal.Z(_assimpMesh->mNormals[vertexIdx].z);
+      normal = rot * normal;
+      normal.Normalize();
+      subMesh.AddNormal(normal);
+    }
     // Iterate over sets of texture coordinates
     for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i)
     {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes there isn't a bug number

## Summary
An assimp mesh could contain either
- the same number of vertices and normals
- only vertices

Existing code crashes when a mesh contains no normals

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸