### PR TITLE
Prepare for 6.0.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common6 VERSION 6.0.0)
+project(gz-common6 VERSION 6.0.1)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 ## Gazebo Common 6.x
 
+### Gazebo Common 6.0.1 (2024-12-17)
+
+1. Check normal presence before trying to read asMesh normals
+    * [Pull request #654](https://github.com/gazebosim/gz-common/pull/654)
+
+1. Include `math::Angle` since it is used here
+    * [Pull request #649](https://github.com/gazebosim/gz-common/pull/649)
+
+1. Adds EoL to example
+    * [Pull request #642](https://github.com/gazebosim/gz-common/pull/642)
+
+1. Remove gts references from documentation
+    * [Pull request #645](https://github.com/gazebosim/gz-common/pull/645)
+
 ## Gazebo Common 6.0.0 (2024-09-25)
 
 1. **Baseline:** this includes all changes from 5.6.0 and earlier.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common6</name>
-  <version>6.0.0</version>
+  <version>6.0.1</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.0.1 release.

Comparison to 6.0.0: https://github.com/gazebosim/gz-common/compare/gz-common6_6.0.0...gz-common6


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.