### PR TITLE
add missing includes

### DIFF
--- a/test/performance/logging.cc
+++ b/test/performance/logging.cc
@@ -16,6 +16,7 @@
 */
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <map>
 #include <thread>

--- a/testing/include/gz/common/testing/detail/AutoLogFixture.hh
+++ b/testing/include/gz/common/testing/detail/AutoLogFixture.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_COMMON_TESTING_DETAIL_AUTOLOGFIXTURE_HH_
 #define GZ_COMMON_TESTING_DETAIL_AUTOLOGFIXTURE_HH_
 
+#include <algorithm>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
## Summary

Hi,

This fix a couple of missing includes:

```cpp
In file included from /build/source/testing/include/gz/common/testing/AutoLogFixture.hh:58,
                 from /build/source/src/MaterialDensity_TEST.cc:20:
/build/source/testing/include/gz/common/testing/detail/AutoLogFixture.hh: In member function 'virtual void gz::common::testing::AutoLogFixture::SetUp()':
/build/source/testing/include/gz/common/testing/detail/AutoLogFixture.hh:79:8: error: 'replace' is not a member of 'std'
   79 |   std::replace(this->dataPtr->logFilename.begin(),
      |        ^~~~~~~
```

and

```cpp
/build/source/test/performance/logging.cc: In function 'void {anonymous}::PrintStats(const std::string&, const std::map<long unsigned int, std::vector<long unsigned int> >&, uint64_t)':
/build/source/test/performance/logging.cc:79:16: error: 'max_element' is not a member of 'std'; did you mean 'tuple_element'?
   79 |         (*std::max_element(t_result.second.begin(), t_result.second.end()));
      |                ^~~~~~~~~~~
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.