### PR TITLE
Fix C4305 double truncated to float warnings

### DIFF
--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -684,7 +684,7 @@ TEST_F(AssimpLoader, LoadGlTF2BoxTransmission)
   const common::MaterialPtr mat = mesh->MaterialByIndex(0u);
   ASSERT_TRUE(mat.get());
   // transmission currently modeled as transparency
-  EXPECT_FLOAT_EQ(0.1, mat->Transparency());
+  EXPECT_FLOAT_EQ(0.1f, mat->Transparency());
   delete mesh;
 #endif
 }
@@ -790,8 +790,8 @@ TEST_F(AssimpLoader, LoadGlbPbrAsset)
   EXPECT_NE(pbr->MetalnessMapData(), nullptr);
   EXPECT_NE(pbr->RoughnessMapData(), nullptr);
   // Check pixel values to test metallicroughness texture splitting
-  EXPECT_FLOAT_EQ(pbr->MetalnessMapData()->Pixel(256, 256).R(), 0.0);
-  EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(), 124.0 / 255.0);
+  EXPECT_FLOAT_EQ(pbr->MetalnessMapData()->Pixel(256, 256).R(), 0.0f);
+  EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(), 124.0f / 255.0f);
 
   // Bug in assimp 5.0.x that doesn't parse coordinate sets properly
   // \todo(iche033) Lightmaps are disabled for glb meshes


### PR DESCRIPTION
# 🦟 Bug fix

Small fix, Windows warnings related to C4305 in a couple of tests.

## Summary
C++ literals default to `double`, and Windows build it's complaining because `EXPECT_FLOAT_EQ` test macros are expecting the use of a `float` type. Changing the literals to use `f`, so they should be using float now.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

