### PR TITLE
Add check for valid indices in submesh

### DIFF
--- a/graphics/include/gz/common/SubMesh.hh
+++ b/graphics/include/gz/common/SubMesh.hh
@@ -405,6 +405,10 @@ namespace gz
       /// the primitive type is not TRIANGLES, or there are no triangles.
       public: double Volume() const;
 
+      /// \brief Verify that all indices point to a valid vertex in the submesh
+      /// \return True if all values of indices are valid, false otherwise.
+      public: bool HasValidIndices() const;
+
       /// \brief Private data pointer.
       GZ_UTILS_IMPL_PTR(dataPtr)
     };

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -625,8 +625,10 @@ struct Neighbors
 void SubMesh::RecalculateNormals()
 {
   if (this->dataPtr->primitiveType != SubMesh::TRIANGLES
-      || this->dataPtr->indices.empty()
       || this->dataPtr->indices.size() % 3u != 0)
+    return;
+
+  if (!this->HasValidIndices())
     return;
 
   // Reset all the normals
@@ -743,6 +745,9 @@ std::string SubMesh::Name() const
 //////////////////////////////////////////////////
 double SubMesh::Volume() const
 {
+  if (!this->HasValidIndices())
+    return 0.0;
+
   double volume = 0.0;
   if (this->dataPtr->primitiveType == SubMesh::TRIANGLES)
   {
@@ -772,6 +777,20 @@ double SubMesh::Volume() const
   }
 
   return volume;
+}
+
+//////////////////////////////////////////////////
+bool SubMesh::HasValidIndices() const
+{
+  if (this->dataPtr->indices.size() == 0u)
+    return false;
+
+  for (unsigned int idx = 0u; idx < this->dataPtr->indices.size(); ++idx)
+  {
+    if (this->dataPtr->indices[idx] >= this->dataPtr->vertices.size())
+      return false;
+  }
+  return true;
 }
 
 //////////////////////////////////////////////////

--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -782,7 +782,7 @@ double SubMesh::Volume() const
 //////////////////////////////////////////////////
 bool SubMesh::HasValidIndices() const
 {
-  if (this->dataPtr->indices.size() == 0u)
+  if (this->dataPtr->indices.empty())
     return false;
 
   for (unsigned int idx = 0u; idx < this->dataPtr->indices.size(); ++idx)

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -598,3 +598,37 @@ TEST_F(SubMeshTest, NormalsRecalculation)
   // because of neighbour vertex
   ASSERT_NE(submesh->Normal(0), submesh->Normal(1));
 }
+
+/////////////////////////////////////////////////
+TEST_F(SubMeshTest, HasValidIndices)
+{
+  // Check empty submesh
+  auto submesh = std::make_shared<common::SubMesh>();
+  EXPECT_FALSE(submesh->HasValidIndices());
+
+  // Check box submesh
+  const common::Mesh *unitBox =
+    common::MeshManager::Instance()->MeshByName("unit_box");
+  ASSERT_TRUE(unitBox != nullptr);
+  auto unitBoxSubmesh = unitBox->SubMeshByIndex(0).lock();
+
+  // Submesh has valid indices and we should be able to calculate normals
+  // and volume
+  EXPECT_TRUE(unitBoxSubmesh->HasValidIndices());
+  unitBoxSubmesh->RecalculateNormals();
+  ASSERT_EQ(unitBoxSubmesh->VertexCount(), unitBoxSubmesh->NormalCount());
+  EXPECT_EQ(24u, unitBoxSubmesh->NormalCount());
+  EXPECT_DOUBLE_EQ(1.0, unitBoxSubmesh->Volume());
+
+  // Add some invalid indices
+  unitBoxSubmesh->AddIndex(100);
+  unitBoxSubmesh->AddIndex(101);
+  unitBoxSubmesh->AddIndex(102);
+
+  // Submesh has invalid indices so it is no longer able to update normals or
+  // compute volume.
+  EXPECT_FALSE(unitBoxSubmesh->HasValidIndices());
+  unitBoxSubmesh->RecalculateNormals();
+  EXPECT_EQ(24u, unitBoxSubmesh->NormalCount());
+  EXPECT_DOUBLE_EQ(0.0, unitBoxSubmesh->Volume());
+}


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix


## Summary
Check for valid indices in submesh before doing operations that make use of them, e.g. `RecalculateNormals` or `Volume` functions. Each index should point to an element in the vertices array. So the check makes sure that we don't have an invalid index that tries to access an element that is out of range of the vertices array. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

