### PR TITLE
ci: run cppcheck, cpplint on noble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,7 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
+        with:
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
+          # codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true
-          doxygen-enabled: true
+          # doxygen-enabled: true

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -613,7 +613,8 @@ ImagePtr AssimpLoader::Implementation::LoadEmbeddedTexture(
 {
   if (_texture->mHeight == 0)
   {
-    Image::PixelFormatType format = Image::PixelFormatType::UNKNOWN_PIXEL_FORMAT;
+    Image::PixelFormatType format =
+        Image::PixelFormatType::UNKNOWN_PIXEL_FORMAT;
     if (_texture->CheckFormat("png"))
     {
       format = Image::PixelFormatType::COMPRESSED_PNG;

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -791,7 +791,8 @@ TEST_F(AssimpLoader, LoadGlbPbrAsset)
   EXPECT_NE(pbr->RoughnessMapData(), nullptr);
   // Check pixel values to test metallicroughness texture splitting
   EXPECT_FLOAT_EQ(pbr->MetalnessMapData()->Pixel(256, 256).R(), 0.0f);
-  EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(), 124.0f / 255.0f);
+  EXPECT_FLOAT_EQ(pbr->RoughnessMapData()->Pixel(256, 256).R(),
+                  124.0f / 255.0f);
 
   // Bug in assimp 5.0.x that doesn't parse coordinate sets properly
   // \todo(iche033) Lightmaps are disabled for glb meshes

--- a/include/gz/common/Console.hh
+++ b/include/gz/common/Console.hh
@@ -129,11 +129,11 @@ namespace gz
       /// \return True when the initialization succeed or false otherwise.
       public: static bool Init(const std::string &_directory,
                                const std::string &_filename);
-     
+
       /// \brief Detach fhe file sink from the global logger. After this call,
       /// console logging will keep working but no file logging.
       public: static void Close();
-      
+
       /// \brief Get the full path of the directory where all the log files
       /// are stored.
       /// \return Full path of the directory.


### PR DESCRIPTION
# 🦟 Bug fix

Part of Part of https://github.com/gazebo-tooling/release-tools/issues/1222

## Summary

Enable linters on Noble. There are doxygen complaints, so just enable cppcheck and cpplint for now.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
