### PR TITLE
Check valid indices before doing convex decomposition

### DIFF
--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -1654,6 +1654,14 @@ MeshManager::ConvexDecomposition(const SubMesh &_subMesh,
                                  std::size_t _maxConvexHulls,
                                  std::size_t _voxelResolution)
 {
+  if (!_subMesh.HasValidIndices())
+  {
+    gzwarn << "Unable to perform convex decomposition on submesh: "
+           <<  _subMesh.Name() << ". It has invalid indices."
+           << std::endl;
+    return {};
+  }
+
   std::vector<SubMesh> decomposed;
 
   auto vertexCount = _subMesh.VertexCount();


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

Same idea as in https://github.com/gazebosim/gz-common/pull/667. This PR adds sanity check for valid indices before doing convex decomposition on the submesh.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
