### PR TITLE
Prepare for 6.1.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common6 VERSION 6.0.2)
+project(gz-common6 VERSION 6.1.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,37 @@
 ## Gazebo Common 6.x
 
+### Gazebo Common 6.1.0 (2025-05-28)
+
+1. Add support for custom profiler
+    * [Pull request #682](https://github.com/gazebosim/gz-common/pull/682)
+
+1. Migrate bazel build setup to use bzlmod
+    * [Pull request #679](https://github.com/gazebosim/gz-common/pull/679)
+    * [Pull request #681](https://github.com/gazebosim/gz-common/pull/681)
+    * [Pull request #683](https://github.com/gazebosim/gz-common/pull/683)
+    * [Pull request #684](https://github.com/gazebosim/gz-common/pull/684)
+
+1. Add Heightmap utility functions
+    * [Pull request #680](https://github.com/gazebosim/gz-common/pull/680)
+
+1. Check valid indices before doing convex decomposition
+    * [Pull request #677](https://github.com/gazebosim/gz-common/pull/677)
+
+1. ci: run cppcheck, cpplint on noble
+    * [Pull request #669](https://github.com/gazebosim/gz-common/pull/669)
+
+1. Added missing includes
+    * [Pull request #672](https://github.com/gazebosim/gz-common/pull/672)
+
+1. Add check for valid indices in submesh
+    * [Pull request #667](https://github.com/gazebosim/gz-common/pull/667)
+
+1. Fix C4305 double truncated to float warnings (#666)
+    * [Pull request #668](https://github.com/gazebosim/gz-common/pull/668)
+
+1. Add missing include chrono in Event.hh header
+    * [Pull request #664](https://github.com/gazebosim/gz-common/pull/664)
+
 ### Gazebo Common 6.0.2 (2025-02-12)
 
 1. Add missing includes

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common6</name>
-  <version>6.0.2</version>
+  <version>6.1.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION

<!-- For maintainers only -->

# 🎈 Release

Preparation for 6.1.0 release.

Comparison to 6.0.2: https://github.com/gazebosim/gz-common/compare/gz-common6_6.0.2...prep_6.1.0



## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
