### PR TITLE
Backport support for custom profiler implementation from gz-common6

### DIFF
--- a/profiler/BUILD.bazel
+++ b/profiler/BUILD.bazel
@@ -1,3 +1,8 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load(
+    "@gz//bazel/lint:lint.bzl",
+    "add_lint_tests",
+)
 load(
     "@gz//bazel/skylark:build_defs.bzl",
     "GZ_FEATURES",
@@ -6,10 +11,6 @@ load(
     "cmake_configure_file",
     "gz_export_header",
     "gz_include_header",
-)
-load(
-    "@gz//bazel/lint:lint.bzl",
-    "add_lint_tests",
 )
 
 package(
@@ -46,21 +47,17 @@ cmake_configure_file(
     visibility = ["//visibility:private"],
 )
 
-public_headers_no_gen = [
-    "include/gz/common/Profiler.hh",
-]
-
-sources = [
-    "src/Profiler.cc",
-    "src/RemoteryProfilerImpl.cc",
-]
-
 gz_export_header(
     name = "include/gz/common/profiler/Export.hh",
     export_base = "GZ_COMMON_PROFILER",
     lib_name = "gz-common-profiler",
     visibility = ["//visibility:private"],
 )
+
+public_headers_no_gen = [
+    "include/gz/common/Profiler.hh",
+    "include/gz/common/ProfilerImpl.hh",
+]
 
 gz_include_header(
     name = "profiler_hh_genrule",
@@ -70,17 +67,6 @@ gz_include_header(
     ],
 )
 
-public_headers = public_headers_no_gen + [
-    "include/gz/common/profiler/Export.hh",
-    "include/gz/common/profiler.hh",
-]
-
-private_headers = [
-    "src/ProfilerImpl.hh",
-    "src/RemoteryProfilerImpl.hh",
-    "include/RemoteryConfig.h",
-]
-
 cc_library(
     name = "remotery",
     srcs = ["src/Remotery/lib/Remotery.c"],
@@ -89,44 +75,106 @@ cc_library(
 )
 
 cc_library(
-    name = "profiler",
-    srcs = sources,
-    hdrs = public_headers + private_headers,
-    defines = [
-        "GZ_PROFILER_ENABLE=1",
-        "GZ_PROFILER_REMOTERY=1",
+    name = "ProfilerImplInterface",
+    hdrs = [
+        "include/gz/common/ProfilerImpl.hh",
+        "include/gz/common/profiler/Export.hh",
+    ],
+    includes = ["include"],
+    visibility = GZ_VISIBILITY,
+)
+
+cc_library(
+    name = "RemoteryProfilerImpl",
+    srcs = ["src/RemoteryProfilerImpl.cc"],
+    hdrs = [
+        "include/RemoteryConfig.h",
+        "src/RemoteryProfilerImpl.hh",
     ],
     includes = ["include"],
     visibility = GZ_VISIBILITY,
     deps = [
         GZ_ROOT + "common",
+        ":ProfilerImplInterface",
         ":remotery",
     ],
 )
 
-cc_test(
-    name = "Profiler_Disabled_TEST",
-    srcs = ["src/Profiler_Disabled_TEST.cc"],
-    copts = ["-Wno-macro-redefined"],
-    defines = [
-        "GZ_PROFILER_ENABLE=0",
-        "GZ_PROFILER_REMOTERY=0",
-    ],
-    deps = [
-        ":profiler",
-        "@gtest",
-        "@gtest//:gtest_main",
+# Build flag to control how the Gz Profiler is configured.
+# --//profiler:config="disabled" (default): Profiler will be disabled.
+# --//profiler:config="remotery": Profiler will be enabled and the Remotery
+#   profiler implemenation will be used.
+# --//profiler:config="custom": Profiler will be enabled and a custom profiler
+#   implementation can be set to be used. See Profiler class for details.
+#
+# Note to maintainers: This setup is different from what is used in CMake where
+# the config is split into two parts to control whether Remotery is used or not
+# separately from whether the profiler is enabled or disabled.
+string_flag(
+    name = "config",
+    build_setting_default = "disabled",
+    values = [
+        "disabled",
+        "remotery",
+        "custom",
     ],
 )
 
-cc_test(
-    name = "Profiler_Remotery_TEST",
-    srcs = ["src/Profiler_Remotery_TEST.cc"],
+config_setting(
+    name = "disabled",
+    flag_values = {
+        ":config": "disabled",
+    },
+)
+
+config_setting(
+    name = "use_remotery",
+    flag_values = {
+        ":config": "remotery",
+    },
+)
+
+config_setting(
+    name = "use_custom",
+    flag_values = {
+        ":config": "custom",
+    },
+)
+
+public_headers = public_headers_no_gen + [
+    "include/gz/common/profiler.hh",
+    "include/gz/common/profiler/Export.hh",
+]
+
+sources = ["src/Profiler.cc"]
+
+cc_library(
+    name = "profiler",
+    srcs = sources,
+    hdrs = public_headers,
+    defines = select({
+        "disabled": [
+            "GZ_PROFILER_ENABLE=0",
+            "GZ_PROFILER_REMOTERY=0",
+        ],
+        "use_remotery": [
+            "GZ_PROFILER_ENABLE=1",
+            "GZ_PROFILER_REMOTERY=1",
+        ],
+        "use_custom": [
+            "GZ_PROFILER_ENABLE=1",
+            "GZ_PROFILER_REMOTERY=0",
+        ],
+    }),
+    includes = ["include"],
+    visibility = GZ_VISIBILITY,
     deps = [
-        ":profiler",
-        "@gtest",
-        "@gtest//:gtest_main",
-    ],
+        GZ_ROOT + "common",
+        ":ProfilerImplInterface",
+    ] + select({
+        "use_remotery": [":RemoteryProfilerImpl"],
+        "//conditions:default": [],
+    }),
 )
 
 add_lint_tests()

--- a/profiler/BUILD.bazel
+++ b/profiler/BUILD.bazel
@@ -177,4 +177,53 @@ cc_library(
     }),
 )
 
+cc_test(
+    name = "Profiler_Disabled_TEST",
+    srcs = ["src/Profiler_Disabled_TEST.cc"],
+    # This test is only compatible with --//profiler:config="disabled"
+    defines = select({
+        "disabled": [],
+        "//conditions:default": ["BAZEL_SKIP_PROFILER_TEST=1"],
+    }),
+    deps = [
+        GZ_ROOT + "common",
+        ":profiler",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "Profiler_Remotery_TEST",
+    srcs = ["src/Profiler_Remotery_TEST.cc"],
+    # This test is only compatible with --//profiler:config="remotery"
+    defines = select({
+        "use_remotery": [],
+        "//conditions:default": ["BAZEL_SKIP_PROFILER_TEST=1"],
+    }),
+    deps = [
+        GZ_ROOT + "common",
+        ":profiler",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "Profiler_Custom_TEST",
+    srcs = ["src/Profiler_Custom_TEST.cc"],
+    # This test is only compatible with --//profiler:config="custom"
+    defines = select({
+        "use_custom": [],
+        "//conditions:default": ["BAZEL_SKIP_PROFILER_TEST=1"],
+    }),
+    deps = [
+        GZ_ROOT + "common",
+        ":ProfilerImplInterface",
+        ":profiler",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)
+
 add_lint_tests()

--- a/profiler/include/gz/common/Profiler.hh
+++ b/profiler/include/gz/common/Profiler.hh
@@ -25,12 +25,12 @@
 #include <gz/common/profiler/Export.hh>
 #include <gz/common/SingletonT.hh>
 
+#include "ProfilerImpl.hh"
+
 namespace gz
 {
   namespace common
   {
-    class ProfilerImpl;
-
     /// \brief Used to perform application-wide performance profiling
     ///
     /// This class provides the necessary infrastructure for recording profiling
@@ -85,6 +85,14 @@ namespace gz
 
       /// \brief End a profiling sample.
       public: void EndSample();
+
+      /// \brief Set a profiler implementation.
+      ///  Takes ownership of the pointer if the call succeeds. This method will
+      ///  fail if a profiler implementation was previously set (i.e. if `Valid`
+      ///  returns `True`).
+      /// \param[in] _impl Profiler implementation to set.
+      /// \return True if the new profiler implementation was accepted.
+      public: bool SetImplementation(std::unique_ptr<ProfilerImpl> _impl);
 
       /// \brief Get the underlying profiler implentation name
       public: std::string ImplementationName() const;

--- a/profiler/include/gz/common/ProfilerImpl.hh
+++ b/profiler/include/gz/common/ProfilerImpl.hh
@@ -21,12 +21,14 @@
 #include <cstdint>
 #include <string>
 
+#include <gz/common/profiler/Export.hh>
+
 namespace gz
 {
   namespace common
   {
     /// \brief Interface to be implemented by profiler implementations.
-    class ProfilerImpl
+    class GZ_COMMON_PROFILER_VISIBLE ProfilerImpl
     {
       /// \brief Constructor.
       public: ProfilerImpl() = default;

--- a/profiler/src/CMakeLists.txt
+++ b/profiler/src/CMakeLists.txt
@@ -65,6 +65,9 @@ if(GZ_PROFILER_REMOTERY)
 
   list(APPEND PROFILER_SRCS ${Remotery_SRC} RemoteryProfilerImpl.cc)
   list(APPEND PROFILER_TESTS Profiler_Remotery_TEST.cc)
+
+else()  # GZ_PROFILER_REMOTERY
+  list(APPEND PROFILER_TESTS Profiler_Custom_TEST.cc)
 endif()
 
 gz_add_component(profiler SOURCES ${PROFILER_SRCS} GET_TARGET_NAME profiler_target)
@@ -102,6 +105,17 @@ gz_build_tests(
 
 if(TARGET UNIT_Profiler_Remotery_TEST)
   target_compile_definitions(UNIT_Profiler_Remotery_TEST
+    PUBLIC "GZ_PROFILER_ENABLE=1")
+endif()
+
+if(TARGET UNIT_Profiler_Error_TEST)
+  target_include_directories(UNIT_Profiler_Error_TEST
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Remotery/lib>
+  )
+endif()
+
+if(TARGET UNIT_Profiler_Custom_TEST)
+  target_compile_definitions(UNIT_Profiler_Custom_TEST
     PUBLIC "GZ_PROFILER_ENABLE=1")
 endif()
 

--- a/profiler/src/Profiler.cc
+++ b/profiler/src/Profiler.cc
@@ -15,11 +15,10 @@
  *
  */
 #include "gz/common/Profiler.hh" // NOLINT(*)
+#include "gz/common/ProfilerImpl.hh"
 #include "gz/common/Console.hh"
 
-#include "ProfilerImpl.hh"
-
-#ifdef GZ_PROFILER_REMOTERY
+#if GZ_PROFILER_REMOTERY
 #include "RemoteryProfilerImpl.hh"
 #endif  // GZ_PROFILER_REMOTERY
 
@@ -30,7 +29,7 @@ using namespace common;
 Profiler::Profiler():
   impl(nullptr)
 {
-#ifdef GZ_PROFILER_REMOTERY
+#if GZ_PROFILER_REMOTERY
   impl = new RemoteryProfilerImpl();
 #endif  // GZ_PROFILER_REMOTERY
 
@@ -95,4 +94,24 @@ std::string Profiler::ImplementationName() const
 bool Profiler::Valid() const
 {
   return this->impl != nullptr;
+}
+
+//////////////////////////////////////////////////
+bool Profiler::SetImplementation(std::unique_ptr<ProfilerImpl> _impl)
+{
+  if (_impl == nullptr)
+  {
+    gzwarn << "Setting an empty profiler implementation is not supported"
+           << std::endl;
+    return false;
+  }
+  if (this->impl != nullptr)
+  {
+    gzwarn << "A profiler implementation named '" << this->impl->Name()
+           << "' is already in use. Cannot set a new one." << std::endl;
+    return false;
+  }
+  this->impl = _impl.release();
+  gzdbg << "Gazebo profiling with: " << this->impl->Name() << std::endl;
+  return true;
 }

--- a/profiler/src/Profiler_Custom_TEST.cc
+++ b/profiler/src/Profiler_Custom_TEST.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +21,57 @@
 #include <atomic> // NOLINT(*)
 #include <thread> // NOLINT(*)
 #include "gz/common/Console.hh"
+#include "gz/common/ProfilerImpl.hh"
 #include "gz/common/Util.hh" // NOLINT(*)
 
 using namespace gz;
 using namespace common;
 
+class CustomProfilerImpl final: public ProfilerImpl
+{
+  public: std::string Name() const final
+  {
+    return "test_profiler";
+  }
+
+  public: void SetThreadName(const char *_name) final {}
+
+  public: void LogText(const char *_text) final {}
+
+  public: void BeginSample(const char *_name, uint32_t *_hash) final
+  {
+    beginSampleCallCount++;
+  }
+
+  public: void EndSample() final
+  {
+    endSampleCallCount++;
+  }
+
+  /// \brief Number of times `BeginSample` was called.
+  public: uint64_t beginSampleCallCount = 0;
+
+  /// \brief Number of times `EndSample` was called.
+  public: uint64_t endSampleCallCount = 0;
+};
+
 /////////////////////////////////////////////////
-TEST(Profiler, ProfilerRemotery)
+TEST(Profiler, CustomProfilerImpl)
 {
 #ifdef BAZEL_SKIP_PROFILER_TEST
   gzerr << "Test case is disabled for current bazel build config." << std::endl;
 #else
   EXPECT_TRUE(GZ_PROFILER_ENABLE);
+  auto profiler = std::make_unique<CustomProfilerImpl>();
+  auto* profilerRawPtr = profiler.get();
+  Profiler::Instance()->SetImplementation(std::move(profiler));
   EXPECT_TRUE(GZ_PROFILER_VALID);
   EXPECT_EQ(Profiler::Instance()->ImplementationName(),
-            "gz_profiler_remotery");
+            "test_profiler");
+  {
+    GZ_PROFILE("Test");
+    EXPECT_EQ(1, profilerRawPtr->beginSampleCallCount);
+  }
+  EXPECT_EQ(1, profilerRawPtr->endSampleCallCount);
 #endif
 }

--- a/profiler/src/Profiler_Disabled_TEST.cc
+++ b/profiler/src/Profiler_Disabled_TEST.cc
@@ -20,6 +20,7 @@
 
 #include <atomic> // NOLINT(*)
 #include <thread> // NOLINT(*)
+#include "gz/common/Console.hh"
 #include "gz/common/Util.hh" // NOLINT(*)
 
 using namespace gz;
@@ -28,6 +29,10 @@ using namespace common;
 /////////////////////////////////////////////////
 TEST(Profiler, ProfilerDisabled)
 {
+#ifdef BAZEL_SKIP_PROFILER_TEST
+  gzerr << "Test case is disabled for current bazel build config." << std::endl;
+#else
   EXPECT_FALSE(GZ_PROFILER_ENABLE);
   EXPECT_FALSE(GZ_PROFILER_VALID);
+#endif
 }

--- a/profiler/src/Profiler_Error_TEST.cc
+++ b/profiler/src/Profiler_Error_TEST.cc
@@ -17,7 +17,7 @@
 
 #include "gz/common/Profiler.hh" // NOLINT(*)
 #include <gtest/gtest.h> // NOLINT(*)
-#include "Remotery/lib/Remotery.h"
+#include "Remotery.h"
 
 #include <gz/common/Export.hh>
 

--- a/profiler/src/RemoteryProfilerImpl.hh
+++ b/profiler/src/RemoteryProfilerImpl.hh
@@ -21,10 +21,10 @@
 #include <string>
 #include <cstdint>
 
+#include "gz/common/ProfilerImpl.hh"
+
 #include "RemoteryConfig.h"
 #include "Remotery.h"
-
-#include "ProfilerImpl.hh"
 
 namespace gz
 {


### PR DESCRIPTION
# 🎉 New feature

## Summary
Backports https://github.com/gazebosim/gz-common/pull/682 to gz-common5.

Repeating the change description here for posterity:

Allow custom profiler implementations to be used with gz-common profiler.

The following changes are made to support this feature:

- A new `SetImplementation` method is added in the singleton Profiler class to set a profiler implementation.
  - This method returns false if an implementation is already in use. This is to avoid complexity from profiler implementations having to be robust against being enabled in the middle of existing scoped profile calls.
  - As a side-effect, `SetImplementation` can only be called once in the process lifetime with a valid profiler implementation.
  - The ProfilerImpl.hh header is moved from profiler/src/ to profiler/include/gz/common/ to allow library users to write custom implementations. Some paths in source files are adjusted accordingly.
  - A new unit test is added to test using a custom profiler implementation. In cmake build, this test is disabled by default and only enabled if the `GZ_PROFILER_REMOTERY` option is false.
- The bazel build is adjusted to use a `--//profiler:config` build flag which can take one of three values: `disabled`, `remotery` or `custom`. This allows the profiler configuration for downstream targets to be controlled at compile time. The default is set to disabled to avoid profiling overhead when the flag is not set explicitly.
  - This setup is different from cmake where the `GZ_PROFILER_REMOTERY` option is used to configure whether the remotery profiler implementaiton will be used for profiling, independently from the `GZ_PROFILER_ENABLE` macro which is used to control whether profiling is enabled or not. This setup difference is intentional since bazel builds for downstream targets will build `gz-common//profiler` from source. So we can expose a single global config setting that can be used to control profiling configuration for downstream targets as well as `gz-common//profiler` itself.
  - The unit tests are adjusted so that the appropriate test is run for each config setting and the other tests are no-op. This is done by introducing a `BAZEL_SKIP_PROFILER_TEST` preprocessor flag that is set for each test appropriately depending on the config setting.

I also had to fix one include in profiler/src/Profiler_Error_TEST.cc since bazel build uses an external remotery library. This needed a corresponding fix in the cmake build as well.


## Test it
Cmake:
```
$ colcon build --merge-install --packages-select gz-common5 --cmake-args '-DGZ_PROFILER_REMOTERY=FALSE'
$ colcon test --merge-install --event-handlers console_direct+ --packages-select gz-common5 --ctest-args -R UNIT_Profiler*
$ rm -rf build/gz-common5
$ colcon build --merge-install --packages-select gz-common5 --cmake-args '-DGZ_PROFILER_REMOTERY=TRUE'
$ colcon test --merge-install --event-handlers console_direct+ --packages-select gz-common5 --ctest-args -R UNIT_Profiler*
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
