### PR TITLE
RedirectConsoleStream: more debugging output

### DIFF
--- a/testing/src/RedirectConsoleStream.cc
+++ b/testing/src/RedirectConsoleStream.cc
@@ -124,7 +124,7 @@ RedirectConsoleStream::RedirectConsoleStream(const StreamSource &_source,
   if (common::exists(this->dataPtr->sink))
   {
     gzerr << "Failed to open sink file: console redirection disabled"
-      << "(destination exists)" << std::endl;
+          << "(" << this->dataPtr->sink << " exists)" << std::endl;
     return;
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

Adds more console output to aid in debugging a failing test

## Summary

Prints the name of the file if it already exists.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
