### PR TITLE
Deprecate MovingWindowFilter, use gz-math instead

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,17 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Common 6.X to 7.X
+
+1. The major version has been removed from the cmake project name and the
+   package.xml package name. Use `find_package(gz-common)` instead of
+   `find_package(gz-commonX)` going forward.
+
+### Deprecations
+
+1. `gz::common::MovingWindowFilter` is deprecated since the functionality
+   was moved to gz-math. Please use `gz::math::MovingWindowFilter` instead.
+
 ## Gazebo Common 5.X to 6.X
 
 ### Modifications

--- a/include/gz/common/MovingWindowFilter.hh
+++ b/include/gz/common/MovingWindowFilter.hh
@@ -65,10 +65,10 @@ namespace gz
     class MovingWindowFilter
     {
       /// \brief Constructor
-      public: MovingWindowFilter();
+      public: GZ_DEPRECATED(7) MovingWindowFilter();
 
       /// \brief Destructor
-      public: virtual ~MovingWindowFilter();
+      public: GZ_DEPRECATED(7) virtual ~MovingWindowFilter();
 
       /// \brief Update value of filter
       /// \param[in] _val new raw value
@@ -92,7 +92,7 @@ namespace gz
 
       /// \brief Allow subclasses to initialize their own data pointer.
       /// \param[in] _d Reference to data pointer.
-      protected: explicit MovingWindowFilter<T>(
+      protected: GZ_DEPRECATED(7) explicit MovingWindowFilter(
                      MovingWindowFilterPrivate<T> &_d);
 
       /// \brief Data pointer.

--- a/include/gz/common/MovingWindowFilter.hh
+++ b/include/gz/common/MovingWindowFilter.hh
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <vector>
+#include <gz/common/Export.hh>
 
 namespace gz
 {

--- a/src/MovingWindowFilter_TEST.cc
+++ b/src/MovingWindowFilter_TEST.cc
@@ -17,10 +17,13 @@
 
 #include <gtest/gtest.h>
 #include <gz/math/Vector3.hh>
+#include <gz/utils/SuppressWarning.hh>
 
 #include "gz/common/MovingWindowFilter.hh"
 
 using namespace gz;
+
+GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
 
 /////////////////////////////////////////////////
 TEST(MovingWindowFilterTest, SetWindowSize)
@@ -69,3 +72,4 @@ TEST(MovingWindowFilterTest, FilterSomething)
         3.0*static_cast<double>(i));
   EXPECT_EQ(vectorMWF.Value(), vsum / 20.0);
 }
+GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION


### PR DESCRIPTION
# 🎉 New feature

Deprecate unused feature now present in gz-math

## Summary

The `gz::common::MovingWindowFilter` class was copied to gz-math 4 in [bitbucket pull request 239](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/239/page/1). The gz-common version is [no longer used in the gazebosim org](https://github.com/search?q=org%3Agazebosim%20common%2FMovingWindowFilter.hh&type=code), so deprecate it.

## Test it

Check that CI has no deprecation warnings.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
