### PR TITLE
Update references of `main` to `gz-common7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-common/tree/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-common/tree/main)
-Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-ci-main-noble-amd64)](https://build.osrfoundation.org/job/gz_common-ci-main-noble-amd64)
-Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/gz_common-ci-main-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/job/gz_common-main-clowin/badge/icon)](https://build.osrfoundation.org/job/gz_common-main-clowin/)
+Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-common/tree/gz-common7/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-common/tree/gz-common7)
+Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-ci-gz-common7-noble-amd64)](https://build.osrfoundation.org/job/gz_common-ci-gz-common7-noble-amd64)
+Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-ci-gz-common7-homebrew-amd64)](https://build.osrfoundation.org/job/gz_common-ci-gz-common7-homebrew-amd64)
+Windows       | [![Build Status](https://build.osrfoundation.org/job/gz_common-7-cnlwin/badge/icon)](https://build.osrfoundation.org/job/gz_common-7-cnlwin/)
 
 Gazebo Common, a component of [Gazebo](https://gazebosim.org), provides a set of libraries that
 cover many different use cases. An audio-visual library supports
@@ -55,11 +55,11 @@ callback system.
 
 # Install
 
-See the [installation tutorial](https://gazebosim.org/api/common/6/install.html).
+See the [installation tutorial](https://gazebosim.org/api/common/7/install.html).
 
 # Usage
 
-Please refer to the [examples directory](https://github.com/gazebosim/gz-common/tree/main/examples).
+Please refer to the [examples directory](https://github.com/gazebosim/gz-common/tree/gz-common7/examples).
 
 # Folder Structure
 

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -25,7 +25,7 @@ In order to use the profiler, inspection points must be added to the source code
 and the application or library must be linked to the `gz-common::profiler`
 component.
 
-To start, download the [profiler.cc](https://github.com/gazebosim/gz-common/raw/main/examples/profiler.cc) example.
+To start, download the [profiler.cc](https://github.com/gazebosim/gz-common/raw/gz-common7/examples/profiler.cc) example.
 
 The relevant corresponding C++ would be as follows:
 
@@ -131,7 +131,7 @@ Run your Gazebo library then go to your Gazebo installation path and open the pr
 
 If the profiler is run successfully, you should see output in a browser. Similar to this
 
-<img src="https://raw.githubusercontent.com/gazebosim/gz-common/main/tutorials/imgs/profiler_tutorial_example.png">
+<img src="https://raw.githubusercontent.com/gazebosim/gz-common/gz-common7/tutorials/imgs/profiler_tutorial_example.png">
 
 ### Troubleshoot the web viewer
 


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/24