### PR TITLE
Add function for extracting single channel data from an RGB[A] image

### DIFF
--- a/graphics/include/gz/common/Image.hh
+++ b/graphics/include/gz/common/Image.hh
@@ -64,7 +64,7 @@ namespace gz
     class GZ_COMMON_GRAPHICS_VISIBLE Image
     {
       /// \brief Image channel
-      public: enum Channel
+      public: enum class Channel
               {
                 /// \brief Red channel
                 RED = 0,

--- a/graphics/include/gz/common/Image.hh
+++ b/graphics/include/gz/common/Image.hh
@@ -63,6 +63,19 @@ namespace gz
     /// \brief Encapsulates an image
     class GZ_COMMON_GRAPHICS_VISIBLE Image
     {
+      /// \brief Image channel
+      public: enum Channel
+              {
+                /// \brief Red channel
+                RED = 0,
+                /// \brief Green channel
+                GREEN = 1,
+                /// \brief Blue channel
+                BLUE = 2,
+                /// \brief Alpha channel
+                ALPHA = 3
+              };
+
       /// \brief Pixel formats enumeration
       public: enum PixelFormatType
               {
@@ -200,6 +213,12 @@ namespace gz
       /// \brief Returns whether this is a valid image
       /// \return true if image has a bitmap
       public: bool Valid() const;
+
+      /// \brief Extract a single channel (red, green, blue, or alpha) from
+      /// an RGB[A] image and return a single channel 8 bit image data.
+      /// \param[in] _channel Channel to extract
+      /// \return 8 bit single channel image data
+      public: std::vector<unsigned char> ChannelData(Channel _channel) const;
 
       /// \brief Convert a single channel image data buffer into an RGB image.
       /// During the conversion, the input image data are normalized to 8 bit

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -583,8 +583,10 @@ std::pair<ImagePtr, ImagePtr>
   std::vector<unsigned char> metalnessData(width * height * bytesPerPixel);
   std::vector<unsigned char> roughnessData(width * height * bytesPerPixel);
 
-  std::vector<unsigned char> metalnessData8bit = _img.ChannelData(Image::BLUE);
-  std::vector<unsigned char> roughnessData8bit = _img.ChannelData(Image::GREEN);
+  std::vector<unsigned char> metalnessData8bit =
+      _img.ChannelData(Image::Channel::BLUE);
+  std::vector<unsigned char> roughnessData8bit =
+      _img.ChannelData(Image::Channel::GREEN);
   for (unsigned int y = 0; y < height; ++y)
   {
     for (unsigned int x = 0; x < width; ++x)

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -589,9 +589,11 @@ std::pair<ImagePtr, ImagePtr>
   {
     for (unsigned int x = 0; x < width; ++x)
     {
-      unsigned int colorB = metalnessData8bit[y * width + x];
-      unsigned int colorG = roughnessData8bit[y * width + x];
-      auto baseIndex = bytesPerPixel * (y * width + x);
+      // RGBA so 4 bytes per pixel, alpha fully opaque
+      unsigned int idx = y * width + x;
+      unsigned int colorB = metalnessData8bit[idx];
+      unsigned int colorG = roughnessData8bit[idx];
+      auto baseIndex = bytesPerPixel * idx;
       metalnessData[baseIndex] = colorB;
       metalnessData[baseIndex + 1] = colorB;
       metalnessData[baseIndex + 2] = colorB;
@@ -602,13 +604,11 @@ std::pair<ImagePtr, ImagePtr>
       roughnessData[baseIndex + 3] = 255;
     }
   }
-
   // First is metal, second is rough
   ret.first = std::make_shared<Image>();
   ret.first->SetFromData(&metalnessData[0], width, height, Image::RGBA_INT8);
   ret.second = std::make_shared<Image>();
   ret.second->SetFromData(&roughnessData[0], width, height, Image::RGBA_INT8);
-
   return ret;
 }
 

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -572,7 +572,7 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
 
 std::pair<ImagePtr, ImagePtr>
     AssimpLoader::Implementation::SplitMetallicRoughnessMap(
-    const Image& _img) const
+    const Image &_img) const
 {
   std::pair<ImagePtr, ImagePtr> ret;
   // Metalness in B roughness in G
@@ -583,28 +583,32 @@ std::pair<ImagePtr, ImagePtr>
   std::vector<unsigned char> metalnessData(width * height * bytesPerPixel);
   std::vector<unsigned char> roughnessData(width * height * bytesPerPixel);
 
+  std::vector<unsigned char> metalnessData8bit = _img.ChannelData(Image::BLUE);
+  std::vector<unsigned char> roughnessData8bit = _img.ChannelData(Image::GREEN);
   for (unsigned int y = 0; y < height; ++y)
   {
     for (unsigned int x = 0; x < width; ++x)
     {
-      // RGBA so 4 bytes per pixel, alpha fully opaque
+      unsigned int colorB = metalnessData8bit[y * width + x];
+      unsigned int colorG = roughnessData8bit[y * width + x];
       auto baseIndex = bytesPerPixel * (y * width + x);
-      auto color = _img.Pixel(x, (height - y - 1));
-      metalnessData[baseIndex] = color.B() * 255.0;
-      metalnessData[baseIndex + 1] = color.B() * 255.0;
-      metalnessData[baseIndex + 2] = color.B() * 255.0;
+      metalnessData[baseIndex] = colorB;
+      metalnessData[baseIndex + 1] = colorB;
+      metalnessData[baseIndex + 2] = colorB;
       metalnessData[baseIndex + 3] = 255;
-      roughnessData[baseIndex] = color.G() * 255.0;
-      roughnessData[baseIndex + 1] = color.G() * 255.0;
-      roughnessData[baseIndex + 2] = color.G() * 255.0;
+      roughnessData[baseIndex] = colorG;
+      roughnessData[baseIndex + 1] = colorG;
+      roughnessData[baseIndex + 2] = colorG;
       roughnessData[baseIndex + 3] = 255;
     }
   }
+
   // First is metal, second is rough
   ret.first = std::make_shared<Image>();
   ret.first->SetFromData(&metalnessData[0], width, height, Image::RGBA_INT8);
   ret.second = std::make_shared<Image>();
   ret.second->SetFromData(&roughnessData[0], width, height, Image::RGBA_INT8);
+
   return ret;
 }
 

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -711,7 +711,7 @@ std::vector<unsigned char> Image::ChannelData(Channel _channel) const
       (this->dataPtr->colorType != FIC_RGB &&
        this->dataPtr->colorType != FIC_RGBALPHA))
   {
-    gzerr << "Extraction of channel data is only support for RGB[A] image"
+    gzerr << "Extraction of channel data is only support for RGB[A] images"
           << std::endl;
     return {};
   }
@@ -719,16 +719,16 @@ std::vector<unsigned char> Image::ChannelData(Channel _channel) const
   FIBITMAP* channelData = nullptr;
   switch (_channel)
   {
-    case RED:
+    case Channel::RED:
       channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_RED);
       break;
-    case GREEN:
+    case Channel::GREEN:
       channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_GREEN);
       break;
-    case BLUE:
+    case Channel::BLUE:
       channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_BLUE);
       break;
-    case ALPHA:
+    case Channel::ALPHA:
       channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_ALPHA);
       break;
     default:
@@ -737,7 +737,8 @@ std::vector<unsigned char> Image::ChannelData(Channel _channel) const
 
   if (!channelData)
   {
-    gzerr << "Invalid input channel: " << _channel << std::endl;
+    gzerr << "Invalid input channel: " << static_cast<int>(_channel)
+          << std::endl;
     return {};
   }
 

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -702,3 +702,48 @@ FIBITMAP* Image::Implementation::SwapRedBlue(const unsigned int &_width,
 
   return copy;
 }
+
+
+//////////////////////////////////////////////////
+std::vector<unsigned char> Image::ChannelData(Channel _channel) const
+{
+  if ((this->dataPtr->imageType != FIT_BITMAP) ||
+      (this->dataPtr->colorType != FIC_RGB &&
+       this->dataPtr->colorType != FIC_RGBALPHA))
+  {
+    gzerr << "Extraction of channeld ata is only support for RGB[A] image"
+          << std::endl;
+    return {};
+  }
+
+  FIBITMAP* channelData = nullptr;
+  switch (_channel)
+  {
+    case RED:
+      channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_RED);
+      break;
+    case GREEN:
+      channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_GREEN);
+      break;
+    case BLUE:
+      channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_BLUE);
+      break;
+    case ALPHA:
+      channelData = FreeImage_GetChannel(this->dataPtr->bitmap, FICC_ALPHA);
+      break;
+    default:
+      break;
+  }
+
+  if (!channelData)
+  {
+    gzerr << "Invalid input channel: " << _channel << std::endl;
+    return {};
+  }
+
+
+  FIBITMAP *tmp = FreeImage_ConvertTo8Bits(channelData);
+  std::vector<unsigned char> data = this->dataPtr->DataImpl(tmp);
+  FreeImage_Unload(tmp);
+  return data;
+}

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include <gz/common/Console.hh>
 #include <gz/common/Util.hh>
@@ -703,7 +704,6 @@ FIBITMAP* Image::Implementation::SwapRedBlue(const unsigned int &_width,
   return copy;
 }
 
-
 //////////////////////////////////////////////////
 std::vector<unsigned char> Image::ChannelData(Channel _channel) const
 {
@@ -740,7 +740,6 @@ std::vector<unsigned char> Image::ChannelData(Channel _channel) const
     gzerr << "Invalid input channel: " << _channel << std::endl;
     return {};
   }
-
 
   FIBITMAP *tmp = FreeImage_ConvertTo8Bits(channelData);
   std::vector<unsigned char> data = this->dataPtr->DataImpl(tmp);

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -711,7 +711,7 @@ std::vector<unsigned char> Image::ChannelData(Channel _channel) const
       (this->dataPtr->colorType != FIC_RGB &&
        this->dataPtr->colorType != FIC_RGBALPHA))
   {
-    gzerr << "Extraction of channeld ata is only support for RGB[A] image"
+    gzerr << "Extraction of channel data is only support for RGB[A] image"
           << std::endl;
     return {};
   }

--- a/graphics/src/Image_TEST.cc
+++ b/graphics/src/Image_TEST.cc
@@ -740,10 +740,14 @@ TEST_F(ImageTest, ChannelData)
   ASSERT_EQ(0, img.Load(kTestData));
   ASSERT_TRUE(img.Valid());
 
-  std::vector<unsigned char> red = img.ChannelData(common::Image::RED);
-  std::vector<unsigned char> green = img.ChannelData(common::Image::GREEN);
-  std::vector<unsigned char> blue = img.ChannelData(common::Image::BLUE);
-  std::vector<unsigned char> alpha = img.ChannelData(common::Image::ALPHA);
+  std::vector<unsigned char> red =
+      img.ChannelData(common::Image::Channel::RED);
+  std::vector<unsigned char> green =
+      img.ChannelData(common::Image::Channel::GREEN);
+  std::vector<unsigned char> blue =
+      img.ChannelData(common::Image::Channel::BLUE);
+  std::vector<unsigned char> alpha =
+      img.ChannelData(common::Image::Channel::ALPHA);
 
   EXPECT_FALSE(red.empty());
   ASSERT_EQ(img.Width() * img.Height(), red.size());

--- a/graphics/src/Image_TEST.cc
+++ b/graphics/src/Image_TEST.cc
@@ -732,6 +732,51 @@ TEST_F(ImageTest, Color16bit)
   }
 }
 
+/////////////////////////////////////////////////
+TEST_F(ImageTest, ChannelData)
+{
+  // load image, extra data from each channel and verify values
+  common::Image img;
+  ASSERT_EQ(0, img.Load(kTestData));
+  ASSERT_TRUE(img.Valid());
+
+  std::vector<unsigned char> red = img.ChannelData(common::Image::RED);
+  std::vector<unsigned char> green = img.ChannelData(common::Image::GREEN);
+  std::vector<unsigned char> blue = img.ChannelData(common::Image::BLUE);
+  std::vector<unsigned char> alpha = img.ChannelData(common::Image::ALPHA);
+
+  EXPECT_FALSE(red.empty());
+  ASSERT_EQ(img.Width() * img.Height(), red.size());
+  ASSERT_EQ(red.size(), green.size());
+  ASSERT_EQ(red.size(), blue.size());
+  ASSERT_EQ(red.size(), alpha.size());
+
+  for (auto i = 0u; i < img.Height(); ++i)
+  {
+    for (auto j = 0u; j < img.Width(); ++j)
+    {
+      unsigned int idx = i * img.Width() + j;
+      unsigned int r = red[idx];
+      unsigned int g = green[idx];
+      unsigned int b = blue[idx];
+      unsigned int a = alpha[idx];
+
+      ASSERT_EQ(0u, g);
+      ASSERT_EQ(255u, a);
+      if (j < 80)
+      {
+        ASSERT_EQ(255u, r);
+        ASSERT_EQ(0u, b);
+      }
+      else
+      {
+        ASSERT_EQ(0u, r);
+        ASSERT_EQ(255u, b);
+      }
+    }
+  }
+}
+
 using string_int2 = std::tuple<const char *, unsigned int, unsigned int>;
 
 class ImagePerformanceTest : public ImageTest,


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->


# 🎉 New feature

Related to https://github.com/gazebosim/jetty_demo/issues/3

## Summary

Adds a new `Image::ChannelData` function to help extract a single channel (r, g, b, or a) from an RGB[A] image.

Thanks for profiling data from @azeey, it was found when loading the Jetty demo world a big chunk of time is spend on splitting the metallic and roughness maps of glb meshes. The main cause of slow down is found to be the [Image::Pixel](https://github.com/gazebosim/gz-common/blob/1edb8408361cc1662e545a328dfaf354db4c20fb/graphics/src/Image.cc#L425) function as the AssimpLoader iterates through every pixel in the image. With the new `Image::ChannelData` function, the AssimpLoader now has a faster and more efficient way of retrieving different channels of the input image. 

Note that the perf issue with `Image::Pixel` function was also noticed in https://github.com/gazebosim/gz-common/pull/699#discussion_r2283641551. Some changes were made to speed it up but seems like it's still not efficient. We'll need to revisit this later on.


For the Jetty demo world, the speed up for splitting the channels of an image was found to be >10x. See example timings (seconds):

* Distribution_Warehouse_Ceiling.001_MetallicRoughness
  * before: 1.22474
  * after: 0.113241
* Distribution_Warehouse_Container.003_MetallicRoughness
  * before: 0.301955
  * after: 0.0263694
* Distribution_Warehouse_Column.001_MetallicRoughness
  * before: 0.304193
  * after: 0.025477
* Distribution_Warehouse_Door.001_MetallicRoughness
  * before: 0.323877
  * after: 0.0263867

The load time for the demo world reduced from 42s (with https://github.com/gazebosim/gz-sim/pull/3070) to 30s on my machine.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
