### PR TITLE
Fix typo in HW accelerate video encoding tutorial

### DIFF
--- a/tutorials/hw-encoding.md
+++ b/tutorials/hw-encoding.md
@@ -212,7 +212,7 @@ messages where `VideoEncoder` documents the detected encoder. It may look like:
 There you can see a NVEnc encoder was successfully used on card `/dev/nvidia1` to
 encode a 2-minute video clip.
 
-If something goes wrong, you'll se a lot of error messages in the console.
+If something goes wrong, you'll see a lot of error messages in the console.
 Sometimes they are helpful, sometimes they are not. In the very worst case,
 wrong configuration may lead to a segfault or any other kind of faulty behavior.
 This is also the reason why HW-acceleration isn't turned on by default.


### PR DESCRIPTION

# 🦟 Bug fix

https://github.com/gazebosim/gazebo_test_cases/issues/1742

## Summary

fix typo

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

