### PR TITLE
Prepare for 7.0.0-pre2 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,16 @@
 
 1. **Baseline:** this includes all changes from 6.1.0 and earlier.
 
+1. Add function for extracting single channel data from an `RGB[A]` image
+    * [Pull request #706](https://github.com/gazebosim/gz-common/pull/706)
+
+1. Documentation updates
+    * [Pull request #707](https://github.com/gazebosim/gz-common/pull/707)
+    * [Pull request #703](https://github.com/gazebosim/gz-common/pull/703)
+
+1. [Bazel] Update bazel module to use jetty release branches
+    * [Pull request #705](https://github.com/gazebosim/gz-common/pull/705)
+
 1. Support reading pixel values from color 16 bit images
     * [Pull request #699](https://github.com/gazebosim/gz-common/pull/699)
 


### PR DESCRIPTION
# 🎈 Release

Preparation for 7.0.0-pre2 release.

Comparison to 7.0.0-pre1: https://github.com/gazebosim/gz-common/compare/gz-common7_7.0.0-pre1...gz-common7

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.