### PR TITLE
[bazel] Bump spdlog version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "freeimage", version = "3.19.10")
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "remotery", version = "1.0.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "spdlog", version = "1.12.0")
+bazel_dep(name = "spdlog", version = "1.15.3")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 bazel_dep(name = "libuuid", version = "2.39.3.bcr.1")
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Bump spdlog dep in Bazel build to 1.15.3 ([latest](https://registry.bazel.build/modules/spdlog)) to fix a compilation issue on MacOS Sequoia. The issue stemmed from pulling in an older unsupported version of `fmt` [transitively](https://github.com/bazelbuild/bazel-central-registry/blob/301ac69537d17e89563609b59562d58a7fb3d982/modules/spdlog/1.12.0/MODULE.bazel#L7):
```
external/fmt~/src/os.cc:300:12: error: out-of-line definition of 'pipe' does not match any declaration in 'fmt::file'
  300 | void file::pipe(file& read_end, file& write_end) {
      |            ^~~~
external/fmt~/src/os.cc:373:6: error: use of undeclared identifier 'file_buffer'
  373 | void file_buffer::grow(size_t) {
      |      ^
external/fmt~/src/os.cc:377:1: error: use of undeclared identifier 'file_buffer'
  377 | file_buffer::file_buffer(cstring_view path,
      | ^
external/fmt~/src/os.cc:383:1: error: use of undeclared identifier 'file_buffer'
  383 | file_buffer::file_buffer(file_buffer&& other)
      | ^
external/fmt~/src/os.cc:383:26: error: unknown type name 'file_buffer'
  383 | file_buffer::file_buffer(file_buffer&& other)
      |                          ^
external/fmt~/src/os.cc:390:1: error: use of undeclared identifier 'file_buffer'
  390 | file_buffer::~file_buffer() {
```

Corresponding PR in gz-utils: https://github.com/gazebosim/gz-utils/pull/188

## Tested:
On Ubuntu:
```
$ bazel build ... 
```

On MacOS Sequoia:
```
$ bazel build --macos_minimum_os=15.5 --features=-layering_check -c opt ...
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
