### PR TITLE
Prepare for 6.2.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common6 VERSION 6.2.0)
+project(gz-common6 VERSION 6.2.1)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,13 @@
 ## Gazebo Common 6.x
 
+### Gazebo Common 6.2.1 (2025-11-12)
+
+1. Fix Image::ChannelData for 16 bit RGB[A] images (backport #720)
+    * [Pull request #721](https://github.com/gazebosim/gz-common/pull/721)
+
 ### Gazebo Common 6.2.0 (2025-11-11)
 
-. Add function for extracting single channel data from an RGB[A] image (backport #706)
+1. Add function for extracting single channel data from an RGB[A] image (backport #706)
     * [Pull request #709](https://github.com/gazebosim/gz-common/pull/709)
 
 1. Support reading pixel values from color 16 bit images (backport #699)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common6</name>
-  <version>6.2.0</version>
+  <version>6.2.1</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION


# 🎈 Release

Preparation for 6.2.1 release.

Comparison to 6.2.0: https://github.com/gazebosim/gz-common/compare/gz-common6_6.2.0...prep_6.2.1



## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
