### PR TITLE
Manual forward port of: Bazel updates (#726)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
 load("@rules_license//rules:license.bzl", "license")
 
@@ -104,3 +106,19 @@ test_sources = glob(
         "@gz-utils//:ExtraTestMacros",
     ],
 ) for src in test_sources]
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,25 +1,25 @@
-## MODULE.bazel
 module(
     name = "gz-common",
-    repo_name = "org_gazebosim_gz-common",
+    compatibility_level = 6,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "assimp", version = "5.4.3.bcr.3")
-bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
 bazel_dep(name = "cdt", version = "1.4.0")
-bazel_dep(name = "freeimage", version = "3.19.10")
-bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "freeimage", version = "3.19.10.bcr.4")
+bazel_dep(name = "googletest", version = "1.15.2")
 bazel_dep(name = "remotery", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "spdlog", version = "1.15.3")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 bazel_dep(name = "libuuid", version = "2.39.3.bcr.1")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_gazebo", version = "0.0.2")
-bazel_dep(name = "gz-utils")
-bazel_dep(name = "gz-math")
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
+bazel_dep(name = "gz-utils", version = "4.0.0")
+bazel_dep(name = "gz-math", version = "9.0.0")
 
 archive_override(
     module_name = "gz-utils",

--- a/av/BUILD.bazel
+++ b/av/BUILD.bazel
@@ -8,17 +8,17 @@ package(
     ],
 )
 
-public_headers_no_gen = glob([
-    "include/gz/common/*.hh",
-    "include/gz/common/**/*.hh",
-])
+# public_headers_no_gen = glob([
+#     "include/gz/common/*.hh",
+#     "include/gz/common/**/*.hh",
+# ])
 
-sources = glob(
-    ["src/*.cc"],
-    exclude = ["src/*_TEST.cc"],
-)
+# sources = glob(
+#     ["src/*.cc"],
+#     exclude = ["src/*_TEST.cc"],
+# )
 
-test_sources = glob(["src/*_TEST.cc"])
+# test_sources = glob(["src/*_TEST.cc"])
 
 gz_export_header(
     name = "Export",
@@ -27,9 +27,9 @@ gz_export_header(
     lib_name = "gz-common-av",
 )
 
-public_headers = public_headers_no_gen + [
-    "include/gz/common/av/Export.hh",
-]
+# public_headers = public_headers_no_gen + [
+#     "include/gz/common/av/Export.hh",
+# ]
 
 # \todo(iche033) Add av component once ffmpeg dep is available in BCR
 # cc_library(

--- a/events/BUILD.bazel
+++ b/events/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 
 package(

--- a/geospatial/BUILD.bazel
+++ b/geospatial/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 
 package(

--- a/graphics/BUILD.bazel
+++ b/graphics/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 
 package(

--- a/io/BUILD.bazel
+++ b/io/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 
 package(

--- a/profiler/BUILD.bazel
+++ b/profiler/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
 
 package(

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
 package(
     default_applicable_licenses = ["//:license"],
     features = [

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 
 package(


### PR DESCRIPTION
The change had to be amended to apply it on main. Specifically, the repo `archive_override`s in MODULE.bazel for gz deps was removed in that PR on the Jetty branch, but we want to preserve it on main to ensure CI uses gz deps from HEAD.

-- Original PR description
Few small fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR.

- Drop `repo_name`, which removes the need to patch MODULE.bazel when pushing a release to BCR. `repo_name` is not a required field and can be added on the client side during import if needed to disambiguate packages.
- Add `compatibility_level` to match [what is set in BCR](https://github.com/bazelbuild/bazel-central-registry/blob/928128b1c60e7e32d21ea8bde9fd802674eba5f3/modules/gz-common/7.0.0-pre1/MODULE.bazel#L5)
- Bump `buildifier_prebuilt` since versions < 8.2.0.1 have a bug in [bazel 8 presubmits](https://github.com/bazelbuild/bazel-central-registry/issues/5037#issuecomment-3020478830). Also add buildifier lint and fix targets in BUILD.bazel.
- Add `rules_cc` and use `cc_library` and `cc_test` from there, rather than native rules which are [deprecated in bazel 9](https://bazel.build/about/roadmap#migration_of_android_c_java_python_and_proto_rules). The buildifier lint target added above already enforces this.
- Comment out unused variables in av/BUILD.bazel
- Bump `freeimage` to latest on BCR (still base version 3.19.10) to pull in [some bazel fixes](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+is%3Aclosed+freeimage) for downstream builds.
- Bump `googletest` and `rules_gazebo` to versions indicated by bazel in [resolved build graph for the repo](https://github.com/gazebosim/gz-common/actions/runs/19647195976/job/56265184516?pr=726#step:8:19).


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
