### PR TITLE
Fix deprecation warnings on including gts headers on macOS

### DIFF
--- a/graphics/src/GTSMeshUtils.cc
+++ b/graphics/src/GTSMeshUtils.cc
@@ -14,13 +14,17 @@
  * limitations under the License.
  *
  */
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-W#pragma-messages"
 // Including gts causes deprecation warnings on certain versions of macOS.
 // Newer versions of Gazebo do not depend on gts, so we'll simply
 // suppress the warning here instead of a more long term solution.
+#endif
 #include <gts.h>
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #include <vector>
 

--- a/graphics/src/MeshCSG.cc
+++ b/graphics/src/MeshCSG.cc
@@ -15,13 +15,17 @@
  *
  */
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-W#pragma-messages"
 // Including gts causes deprecation warnings on certain versions of macOS.
 // Newer versions of Gazebo do not depend on gts, so we'll simply
 // suppress the warning here instead of a more long term solution.
+#endif
 #include <gts.h>
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #include <string>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-common/issues/727

## Summary
The gts headers are included via the flags `-I` and `-isystem`. Apparently, some compilers will let  the `-isystem` override, which seems to be the case on Sequoia, but not on Sonoma. The solution here is to suppress the warnings with pragma directives.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

