### PR TITLE
Print full `parentPath` and `templatePath` to check `https://github.com/gazebosim/gz-common/issues/676#issuecomment-3687618020`

### DIFF
--- a/src/TempDirectory.cc
+++ b/src/TempDirectory.cc
@@ -134,7 +134,12 @@ std::string gz::common::createTempDirectory(
     ret = "";
     if(FSWO_LOG_WARNINGS == _warningOp)
     {
-      gzwarn << "Failed to create temp directory: " << ex.what() << "\n";
+      fs::path parentPath{_parentPath};
+      fs::path templatePath = _baseName + "XXXXXX";
+      auto fullTemplateStr = (parentPath / templatePath).string();
+      gzwarn << "Failed to create temp directory: " << ex.what()
+             << " | parentPath: " << parentPath.string()
+             << " | templatePath: " << fullTemplateStr << "\n";
     }
   }
   return ret;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug check

To check `https://github.com/gazebosim/gz-common/issues/676#issuecomment-3687618020`

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This pr is to check `https://github.com/gazebosim/gz-common/issues/676#issuecomment-3687618020`, which is a failure in `AssimpLoader.CheckNonRootDisplacement` test failure. it says

```
[TempDirectory.cc:137] Failed to create temp directory: could not format the temp directory name template: The system cannot move the file to a different disk drive.
```

Do not merge!!

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
