### PR TITLE
Prepare for 6.3.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common6 VERSION 6.2.1)
+project(gz-common6 VERSION 6.3.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 ## Gazebo Common 6.x
 
+### Gazebo Common 6.3.0 (2026-01-28)
+
+1. Add functions for clearing FindFile* callbacks
+    * [Pull request #754](https://github.com/gazebosim/gz-common/pull/754)
+
+1. TempDirectory: improve windows reliability
+    * [Pull request #744](https://github.com/gazebosim/gz-common/pull/744)
+
+1. [bazel/infra] Add manual BCR release workflow
+    * [Pull request #732](https://github.com/gazebosim/gz-common/pull/732)
+
+1. Manual backport of: Bazel updates
+    * [Pull request #726](https://github.com/gazebosim/gz-common/pull/726)
+
 ### Gazebo Common 6.2.1 (2025-11-12)
 
 1. Fix Image::ChannelData for 16 bit RGB[A] images (backport #720)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common6</name>
-  <version>6.2.1</version>
+  <version>6.3.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.3.0 release.

Comparison to 6.2.1: https://github.com/gazebosim/gz-common/compare/gz-common6_6.2.1...gz-common6

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.