### PR TITLE
Prepare for 5.8.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.7.1)
+project(gz-common5 VERSION 5.8.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,37 @@
 ## Gazebo Common 5.x
 
+### Gazebo Common 5.8.0 (2026-01-28)
+
+1. Add functions for clearing FindFile* callbacks
+    * [Pull request #754](https://github.com/gazebosim/gz-common/pull/754)
+
+1. TempDirectory: improve windows reliability
+    * [Pull request #744](https://github.com/gazebosim/gz-common/pull/744)
+
+1. Fix deprecation warnings on including gts headers on macOS
+    * [Pull request #739](https://github.com/gazebosim/gz-common/pull/739)
+
+1. Fix Image::ChannelData for 16 bit RGB[A] images
+    * [Pull request #720](https://github.com/gazebosim/gz-common/pull/720)
+
+1. Add function for extracting single channel data from an RGB[A] image
+    * [Pull request #706](https://github.com/gazebosim/gz-common/pull/706)
+
+1. Add missing includes
+    * [Pull request #660](https://github.com/gazebosim/gz-common/pull/660)
+
+1. Support reading pixel values from color 16 bit images
+    * [Pull request #699](https://github.com/gazebosim/gz-common/pull/699)
+
+1. Add support for custom profiler
+    * [Pull request #682](https://github.com/gazebosim/gz-common/pull/682)
+
+1. Check valid indices before doing convex decomposition
+    * [Pull request #677](https://github.com/gazebosim/gz-common/pull/677)
+
+1. Add check for valid indices in submesh
+    * [Pull request #667](https://github.com/gazebosim/gz-common/pull/667)
+
 ### Gazebo Common 5.7.1 (2025-01-30)
 
 1. Add include <chrono> for system_clock in Event.hh

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common5</name>
-  <version>5.7.1</version>
+  <version>5.8.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.8.0 release.

Comparison to 5.7.1: https://github.com/gazebosim/gz-common/compare/gz-common5_5.7.1...gz-common5

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.