### PR TITLE
av:Fix memory leak in video and videoEncoder

### DIFF
--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -288,7 +288,7 @@ bool Video::NextFrame(unsigned char **_buffer)
 
   while (frameAvailable == 0)
   {
-    if(!this->dataPtr->drainingMode)
+    if (!this->dataPtr->drainingMode)
     {
       packet = av_packet_alloc();
       if (!packet)
@@ -297,11 +297,11 @@ bool Video::NextFrame(unsigned char **_buffer)
         return false;
       }
     
-    // this loop will always exit because each call to AVCodecDecode()
-    // reads from the input buffer and it has to either end at some time or
-    // return a valid frame
+      // this loop will always exit because each call to AVCodecDecode()
+      // reads from the input buffer and it has to either end at some time or
+      // return a valid frame
 
-    // in draining mode, we no longer read the input stream as it has ended
+      // in draining mode, we no longer read the input stream as it has ended
       // read a frame from the input stream
       ret = av_read_frame(this->dataPtr->formatCtx, packet);
       if (ret < 0)

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -108,19 +108,40 @@ Video::~Video()
 void Video::Cleanup()
 {
   // Free the YUV frame
-  av_free(this->dataPtr->avFrame);
+  if (this->dataPtr->avFrame)
+  {
+    av_frame_free(&this->dataPtr->avFrame);
+  }
 
   // Close the video file
-  avformat_close_input(&this->dataPtr->formatCtx);
+  if (this->dataPtr->formatCtx)
+  {
+    avformat_close_input(&this->dataPtr->formatCtx);
+  }
 
   // Close the codec
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
-  avcodec_free_context(&this->dataPtr->codecCtx);
+  if (this->dataPtr->codecCtx)
+  {
+    avcodec_free_context(&this->dataPtr->codecCtx);
+  }
 #else
-  avcodec_close(this->dataPtr->codecCtx);
+  if (this->dataPtr->codecCtx)
+  {
+    avcodec_close(this->dataPtr->codecCtx);
+  }
 #endif
 
-  av_free(this->dataPtr->avFrameDst);
+  if (this->dataPtr->avFrameDst)
+  {
+    av_frame_free(&this->dataPtr->avFrameDst);
+  }
+
+  if (this->dataPtr->swsCtx)
+  {
+    sws_freeContext(this->dataPtr->swsCtx);
+    this->dataPtr->swsCtx = nullptr;
+  }
 }
 
 /////////////////////////////////////////////////
@@ -261,26 +282,26 @@ bool Video::Load(const std::string &_filename)
 /////////////////////////////////////////////////
 bool Video::NextFrame(unsigned char **_buffer)
 {
-  AVPacket* packet;
+  AVPacket* packet = nullptr;
   int frameAvailable = 0;
   int ret;
 
   while (frameAvailable == 0)
   {
-    packet = av_packet_alloc();
-    if (!packet)
+    if(!this->dataPtr->drainingMode)
     {
-      gzerr << "Failed to allocate AVPacket" << std::endl;
-      return false;
-    }
-
+      packet = av_packet_alloc();
+      if (!packet)
+      {
+        gzerr << "Failed to allocate AVPacket" << std::endl;
+        return false;
+      }
+    
     // this loop will always exit because each call to AVCodecDecode()
     // reads from the input buffer and it has to either end at some time or
     // return a valid frame
 
     // in draining mode, we no longer read the input stream as it has ended
-    if (!this->dataPtr->drainingMode)
-    {
       // read a frame from the input stream
       ret = av_read_frame(this->dataPtr->formatCtx, packet);
       if (ret < 0)
@@ -290,20 +311,26 @@ bool Video::NextFrame(unsigned char **_buffer)
           // end of stream, enter draining mode
           avcodec_send_packet(this->dataPtr->codecCtx, nullptr);
           this->dataPtr->drainingMode = true;
+          av_packet_free(&packet);
         }
         else
         {
           gzerr << "Error reading packet: " << av_err2str_cpp(ret)
                  << ". Stopped reading the file." << std::endl;
+          av_packet_free(&packet);
           return false;
         }
       }
       else if (packet->stream_index != this->dataPtr->videoStream)
       {
         // packet belongs to a stream we're not interested in (e.g. audio)
-        av_packet_unref(packet);
+        av_packet_free(&packet);
         continue;
       }
+    }
+    else
+    {
+      packet = nullptr;
     }
 
     // Process all the data in the frame
@@ -314,7 +341,7 @@ bool Video::NextFrame(unsigned char **_buffer)
     if (ret == AVERROR_EOF)
     {
       if (!this->dataPtr->drainingMode)
-        av_packet_unref(packet);
+        av_packet_free(&packet);
       return false;
     }
     else if (ret < 0)
@@ -323,8 +350,8 @@ bool Video::NextFrame(unsigned char **_buffer)
              << av_err2str_cpp(ret) << std::endl;
       // continue processing data
     }
-    if (!this->dataPtr->drainingMode)
-      av_packet_unref(packet);
+    if (packet)
+      av_packet_free(&packet);
   }
 
   // processing the image if available

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -776,7 +776,7 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
         ret = this->dataPtr->ProcessPacket(avPacket);
     }
 
-    av_packet_unref(avPacket);
+    av_packet_free(&avPacket);
   }
   return ret >= 0 || ret == AVERROR(EAGAIN);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes part of #665 

## Summary
asan problem todo list in https://build.osrfoundation.org/view/gz-harmonic/job/gz_common-ci_asan-gz-common5-jammy-amd64/203/#showFailuresLink

This fixes asan problem(memory leak) when running `INTEGRATION_video_encoder`
Before fix : 
```
==45756==ERROR: LeakSanitizer: detected memory leaks 
SUMMARY: AddressSanitizer: 549632 byte(s) leaked in 290 allocation(s).
```
After fix : no asan error output

major changes : 
1. replace `av_packet_unref(&packet)` with `av_packet_free(&packet)`  in both `Video::NextFrame` and `VideoEncoder::AddFrame` fixes `AVPacket` Struct Leaks (Misuse of `unref` vs `free`) 
2. refactored the while loop to only allocate `AVPacket` when `!drainingMode`. If `EOF` is reached, the packet is immediately freed before entering the drain phase.
(avoid continuing to allocate a new `AVPacket` at the top of the loop)
4. replaced `av_free()` with `av_frame_free(&...)` and added the missing `sws_freeContext(swsCtx)` in the cleanup routines.
(missing deep teardowns in `Cleanup`)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: 

Note to maintainers: Remember to use Squash-Merge and edit the commit message to match the pull request summary while retaining Signed-off-by and Generated-by messages.

Backports: If this is a backport, please use Rebase and Merge instead
