### PR TITLE
Add GZ_CONSOLE_COLOR env variable to control terminal color output

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ See the [installation tutorial](https://gazebosim.org/api/common/5/install.html)
 
 Please refer to the [examples directory](https://github.com/gazebosim/gz-common/tree/main/examples).
 
+Console color output can be controlled with `GZ_CONSOLE_COLOR`:
+
+* `yes`: always emit ANSI color codes.
+* `no`: never emit ANSI color codes.
+
+Only `yes` and `no` are recognized. Other values are ignored with a warning.
+
 # Folder Structure
 
 Refer to the following table for information about important directories and files in this repository.

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -28,6 +28,34 @@
 using namespace gz;
 using namespace common;
 
+#define CONSOLE_COLOR_ON 1
+#define CONSOLE_COLOR_OFF 0
+
+static int consoleColorMode = CONSOLE_COLOR_ON;
+
+/////////////////////////////////////////////////
+static void UpdateConsoleColorMode()
+{
+  std::string consoleColor;
+  if (!env("GZ_CONSOLE_COLOR", consoleColor))
+    return;
+
+  const auto value = lowercase(trimmed(consoleColor));
+  if (value == "yes")
+  {
+    consoleColorMode = CONSOLE_COLOR_ON;
+  }
+  else if (value == "no")
+  {
+    consoleColorMode = CONSOLE_COLOR_OFF;
+  }
+  else
+  {
+    std::cerr << "Invalid value for GZ_CONSOLE_COLOR='" << consoleColor
+      << "'. Valid values are: yes, no." << std::endl;
+  }
+}
+
 
 FileLogger common::Console::log("");
 
@@ -156,7 +184,11 @@ int Logger::Buffer::sync()
       outstr.pop_back();
 
     std::stringstream ss;
-    ss << "\033[1;" << this->color << "m" << outstr << "\033[0m";
+    if (consoleColorMode == CONSOLE_COLOR_OFF)
+      ss << outstr;
+    else
+      ss << "\033[1;" << this->color << "m" << outstr << "\033[0m";
+
     if (lastNewLine)
       ss << std::endl;
 
@@ -190,7 +222,7 @@ int Logger::Buffer::sync()
 
     {
       std::lock_guard<std::mutex> lk(this->syncMutex);
-      if (vtProcessing)
+      if (vtProcessing && consoleColorMode != CONSOLE_COLOR_OFF)
         outStream << "\x1b[" << this->color << "m" << outstr << "\x1b[m";
       else
         outStream << outstr;
@@ -233,6 +265,8 @@ void FileLogger::Init(const std::string &_directory,
                       const std::string &_filename)
 {
   std::string logPath;
+
+  UpdateConsoleColorMode();
 
   if (_directory.empty() ||
 #ifndef _WIN32

--- a/src/Console_TEST.cc
+++ b/src/Console_TEST.cc
@@ -549,3 +549,71 @@ TEST_F(Console_TEST, NoInitAndLogNoHome)
   // This should not throw
   gzlog << "this is a test" << std::endl;
 }
+
+/////////////////////////////////////////////////
+/// \brief Test Console color output with GZ_CONSOLE_COLOR=yes
+TEST_F(Console_TEST, ConsoleColorYes)
+{
+  common::Console::SetVerbosity(3);
+  EXPECT_TRUE(common::setenv("GZ_CONSOLE_COLOR", "yes"));
+
+  // Initialize 
+  auto path = common::uuid();
+  gzLogInit(path, "test.log");
+
+  // stdout to check for ANSI codes
+  testing::internal::CaptureStdout();
+  gzmsg << "color yes test" << std::endl;
+  std::string output = testing::internal::GetCapturedStdout();
+
+#ifndef _WIN32
+  // Check for ANSI escape sequence
+  EXPECT_TRUE(output.find("\033[") != std::string::npos);
+#endif
+
+  EXPECT_TRUE(common::unsetenv("GZ_CONSOLE_COLOR"));
+  common::Console::SetVerbosity(1);
+  gzLogClose();
+}
+
+/////////////////////////////////////////////////
+/// \brief Test Console color output with GZ_CONSOLE_COLOR=no
+TEST_F(Console_TEST, ConsoleColorNo)
+{
+  common::Console::SetVerbosity(3);
+  EXPECT_TRUE(common::setenv("GZ_CONSOLE_COLOR", "no"));
+
+  // Initialize 
+  auto path = common::uuid();
+  gzLogInit(path, "test.log");
+
+  // stdout to check for no ANSI codes
+  testing::internal::CaptureStdout();
+  gzmsg << "color no test" << std::endl;
+  std::string output = testing::internal::GetCapturedStdout();
+
+  // Check for no ANSI escape sequence
+  EXPECT_TRUE(output.find("\033[") == std::string::npos);
+
+  EXPECT_TRUE(common::unsetenv("GZ_CONSOLE_COLOR"));
+  common::Console::SetVerbosity(1);
+  gzLogClose();
+}
+
+/////////////////////////////////////////////////
+/// \brief Test invalid GZ_CONSOLE_COLOR value warning
+TEST_F(Console_TEST, ConsoleColorInvalid)
+{
+  EXPECT_TRUE(common::setenv("GZ_CONSOLE_COLOR", "maybe"));
+
+  // check stderr to check for warning message
+  testing::internal::CaptureStderr();
+  auto path = common::uuid();
+  gzLogInit(path, "test.log");
+  std::string output = testing::internal::GetCapturedStderr();
+
+  EXPECT_TRUE(output.find("Invalid value for GZ_CONSOLE_COLOR") != std::string::npos);
+
+  EXPECT_TRUE(common::unsetenv("GZ_CONSOLE_COLOR"));
+  gzLogClose();
+}


### PR DESCRIPTION

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->


# 🎉 New feature


Closes #611

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

If the env variable is yes , the ANSI color codes are on for logging. When it is no, it disables ANSI colors 

-- Testing GZ_CONSOLE_COLOR = yes ---
^[[32m(2026-03-06 13:16:01.402) [info] [test_color.cc:10] This is an info message
^[[m^[[33m^[[1m(2026-03-06 13:16:01.402) [warning] [test_color.cc:11] This is a warning message
^[[m^[[31m^[[1m(2026-03-06 13:16:01.402) [error] [test_color.cc:12] This is an error message

after turning the color_mode to no  the outputs do not contain the asci color codes.

--- Testing GZ_CONSOLE_COLOR = no---
(2026-03-06 13:16:01.404) [info] [test_color.cc:10] This is an info message
(2026-03-06 13:16:01.404) [warning] [test_color.cc:11] This is a warning message
(2026-03-06 13:16:01.404) [error] [test_color.cc:12] This is an error message
(2026-03-06 13:16:01.404) [debug] [test_color.cc:13] This is a debug message


Need to add a logger wrapper in gz-utils to change the color_mode through sink. that is done in this pr -> [gazebosim/gz-utils#205](https://github.com/gazebosim/gz-utils/pull/205)
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [X] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
