### PR TITLE
Use rotary alias packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -4,10 +4,10 @@ libavdevice-dev
 libavformat-dev
 libavutil-dev
 libgdal-dev
-libgz-cmake5-dev
-libgz-math9-dev
-libgz-utils4-dev
-libgz-utils4-log-dev
+libgz-rotary-cmake-dev
+libgz-rotary-math-dev
+libgz-rotary-utils-dev
+libgz-rotary-utils-log-dev
 libspdlog-dev
 libswscale-dev
 libtinyxml2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
+          gzdev-project-name: rotary
           # codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true


### PR DESCRIPTION
Use rotary alias packages for CI

Related to https://github.com/gazebo-tooling/release-tools/issues/1446