### PR TITLE
[bazel] Update Profiler dependency

### DIFF
--- a/profiler/BUILD.bazel
+++ b/profiler/BUILD.bazel
@@ -153,6 +153,7 @@ cc_library(
     deps = [
         ":ProfilerImplInterface",
         "//:gz-common",
+        "@gz-utils//:NeverDestroyed",
     ] + select({
         "use_remotery": [":RemoteryProfilerImpl"],
         "//conditions:default": [],


### PR DESCRIPTION


# 🦟 Bug fix

## Summary
Fixes profiler deps as it was found broken in https://github.com/gazebosim/gz-sim/pull/3405 with the following error:

```
external/gz-common~/profiler/include/gz/common/Profiler.hh:27:10: error: module gz-common~//profiler:profiler does not depend on a module exporting 'gz/utils/NeverDestroyed.hh'
```

This could be due to recent changes in https://github.com/gazebosim/gz-common/pull/779. I was able to reproduce this locally with bazel 8 + clang. This PR adds the NeverDestroyed dep to fix the build issue.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
