### PR TITLE
feat: Add API for requesting a new mesh from the MeshManager

### DIFF
--- a/graphics/include/gz/common/MeshManager.hh
+++ b/graphics/include/gz/common/MeshManager.hh
@@ -107,7 +107,11 @@ namespace gz
       /// This MeshManager takes ownership of the mesh and will destroy it.
       /// See ~MeshManager.
       /// \param[in] the mesh to add.
-      public: void AddMesh(Mesh *_mesh);
+      /// \deprecated This API requires the user to allocate a Mesh object on
+      /// the heap and "move" it into MeshManager. However, this is not safe to
+      /// do across shared library boundaries and may cause segfaults during
+      /// MeshManager destruction. Use \ref CreateMesh instead
+      public: void GZ_DEPRECATED(8) AddMesh(Mesh *_mesh);
 
       /// \brief Remove a mesh based on a name.
       /// \param[in] _name Name of the mesh to remove.

--- a/graphics/include/gz/common/MeshManager.hh
+++ b/graphics/include/gz/common/MeshManager.hh
@@ -128,11 +128,11 @@ namespace gz
       /// \param[in] _name the name of the mesh
       public: bool HasMesh(const std::string &_name) const;
 
-      /// \brief Create an empty mesh and register it by name. If the mesh already
-      /// exists, returns nullptr.
+      /// \brief Create an empty mesh and register it by name. If the mesh
+      /// already exists, returns nullptr.
       /// \param[in] _name the name of the new mesh
-      /// \return a mutable pointer pointing to the newly allocated mesh, or nullptr
-      /// if the mesh name is already claimed.
+      /// \return a mutable pointer pointing to the newly allocated mesh, or
+      /// nullptr if the mesh name is already claimed.
       public: common::Mesh *CreateMesh(const std::string &_name);
 
       /// \brief Create a sphere mesh.

--- a/graphics/include/gz/common/MeshManager.hh
+++ b/graphics/include/gz/common/MeshManager.hh
@@ -128,6 +128,13 @@ namespace gz
       /// \param[in] _name the name of the mesh
       public: bool HasMesh(const std::string &_name) const;
 
+      /// \brief Create an empty mesh and register it by name. If the mesh already
+      /// exists, returns nullptr.
+      /// \param[in] _name the name of the new mesh
+      /// \return a mutable pointer pointing to the newly allocated mesh, or nullptr
+      /// if the mesh name is already claimed.
+      public: common::Mesh *CreateMesh(const std::string &_name);
+
       /// \brief Create a sphere mesh.
       /// \param[in] _name the name of the mesh
       /// \param[in] _radius radius of the sphere in meter

--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -264,6 +264,12 @@ void MeshManager::AddMesh(Mesh *_mesh)
 //////////////////////////////////////////////////
 Mesh *MeshManager::CreateMesh(const std::string &_name)
 {
+  if (_name.empty())
+  {
+    gzerr << "Valid mesh name required." << std::endl;
+    return nullptr;
+  }
+
   if (this->HasMesh(_name))
   {
     gzerr << "Mesh [" << _name << "] already exists." << std::endl;

--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -262,6 +262,21 @@ void MeshManager::AddMesh(Mesh *_mesh)
 }
 
 //////////////////////////////////////////////////
+Mesh *MeshManager::CreateMesh(const std::string &_name)
+{
+  if (this->HasMesh(_name))
+  {
+    gzerr << "Mesh [" << _name << "] already exists." << std::endl;
+    return nullptr;
+  }
+
+  Mesh *newMesh = new Mesh();
+  newMesh->SetName(_name);
+  this->dataPtr->meshes[_name] = newMesh;
+  return newMesh;
+}
+
+//////////////////////////////////////////////////
 const Mesh *MeshManager::MeshByName(const std::string &_name) const
 {
   auto iter = this->dataPtr->meshes.find(_name);

--- a/graphics/src/MeshManager_TEST.cc
+++ b/graphics/src/MeshManager_TEST.cc
@@ -425,4 +425,37 @@ TEST_F(MeshManager, MergeSubMeshes)
   EXPECT_EQ(math::Vector2d(0, 0.6), mergedSubmesh->TexCoordBySet(5u, 2u));
 }
 
+/////////////////////////////////////////////////
+TEST_F(MeshManager, CreateMesh)
+{
+  auto *mgr = common::MeshManager::Instance();
+  std::string meshName = "test_create_mesh";
+
+  // Pre-condition
+  EXPECT_FALSE(mgr->HasMesh(meshName));
+  EXPECT_EQ(nullptr, mgr->MeshByName(meshName));
+
+  // Create the mesh
+  common::Mesh *mutableMesh = mgr->CreateMesh(meshName);
+  ASSERT_NE(nullptr, mutableMesh);
+  EXPECT_EQ(meshName, mutableMesh->Name());
+
+  // Fetch the newly created mesh
+  const common::Mesh *cachedMesh = mgr->MeshByName(meshName);
+  ASSERT_NE(nullptr, cachedMesh);
+  EXPECT_EQ(mutableMesh, cachedMesh);
+  EXPECT_TRUE(mgr->HasMesh(meshName));
+
+  // Attempt to create the same mesh again should return nullptr safely
+  common::Mesh *duplicateMesh = mgr->CreateMesh(meshName);
+  EXPECT_EQ(nullptr, duplicateMesh);
+
+  // Verify original mesh is intact
+  const common::Mesh *verifyMesh = mgr->MeshByName(meshName);
+  EXPECT_NE(nullptr, verifyMesh);
+  EXPECT_EQ(meshName, verifyMesh->Name());
+
+  mgr->RemoveAll();
+}
+
 #endif


### PR DESCRIPTION
# 🎉 New feature

## Summary
This allows allocating new `common::Mesh` objects within the gz-common shared library avoiding cross-shared library lifetime mismatch issues. Such issues currently cause a segfault in gz-physics [COMMON_TEST_collisions_bullet-featherstone](https://build.osrfoundation.org/view/gz-rotary/job/gz_physics-main-cnlwin/97/console) test, even though Jenkins doesn't report it (I'm working on a fix for that too).


## Test it
Run `UNIT_MeshManager_TEST`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
