### PR TITLE
C++ memory fixes for tests

### DIFF
--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -73,6 +73,9 @@ TEST(AudioDecoder, DataBuffer)
 
   EXPECT_EQ(dataBufferSize2, dataBufferSize);
   EXPECT_EQ(sizeof(dataBuffer), sizeof(dataBuffer2));
+
+  free(dataBuffer);
+  free(dataBuffer2);
 }
 
 /////////////////////////////////////////////////
@@ -150,4 +153,6 @@ TEST(AudioDecoder, GZ_UTILS_TEST_DISABLED_ON_WIN32(CheerFile))
                 dataBufferSize == 4987612u ||
                 dataBufferSize == 4987612u * 2);
   }
+
+  free(dataBuffer);
 }

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -888,4 +888,5 @@ TEST_F(AssimpLoader, NoAnimName)
   common::SkeletonAnimation *anim = skeleton->Animation(0);
   auto animName = anim->Name();
   EXPECT_EQ(animName, "animation1");
+  delete mesh;
 }

--- a/graphics/src/ColladaLoader_TEST.cc
+++ b/graphics/src/ColladaLoader_TEST.cc
@@ -520,4 +520,5 @@ TEST_F(ColladaLoader, NoAnimName)
   common::SkeletonAnimation *anim = skeleton->Animation(0);
   auto animName = anim->Name();
   EXPECT_EQ(animName, "animation1");
+  delete mesh;
 }

--- a/src/SignalHandler_TEST.cc
+++ b/src/SignalHandler_TEST.cc
@@ -31,7 +31,7 @@ using namespace gz;
 
 // Capture the gOnSignalWrappers map from SignalHandlers.cc
 #ifndef _WIN32
-extern std::map<int, std::function<void(int)>>& gOnSignalWrappers;
+extern std::map<int, std::function<void(int)>> gOnSignalWrappers;
 #endif
 
 int gHandler1Sig = -1;

--- a/src/SignalHandler_TEST.cc
+++ b/src/SignalHandler_TEST.cc
@@ -31,7 +31,7 @@ using namespace gz;
 
 // Capture the gOnSignalWrappers map from SignalHandlers.cc
 #ifndef _WIN32
-extern std::map<int, std::function<void(int)>> gOnSignalWrappers;
+extern std::map<int, std::function<void(int)>>& gOnSignalWrappers;
 #endif
 
 int gHandler1Sig = -1;


### PR DESCRIPTION
# 🦟 Bug fix

Part of #665 

## Summary

Memory management improvements in tests:

* Added `free(dataBuffer)` and `free(dataBuffer2)` calls to clean up allocated memory in `TEST(AudioDecoder, DataBuffer)` and `TEST(AudioDecoder, GZ_UTILS_TEST_DISABLED_ON_WIN32(CheerFile)` in `av/src/AudioDecoder_TEST.cc`. [[1]](diffhunk://#diff-499530e1e17aa5c964e5ae5c3c1b509d02eb930e9233885c378099ccc8a24538R76-R78) [[2]](diffhunk://#diff-499530e1e17aa5c964e5ae5c3c1b509d02eb930e9233885c378099ccc8a24538R156-R157)
* Added `delete mesh;` to clean up dynamically allocated meshes in `TEST_F(AssimpLoader, NoAnimName)` in `graphics/src/AssimpLoader_TEST.cc` and `TEST_F(ColladaLoader, NoAnimName)` in `graphics/src/ColladaLoader_TEST.cc`. [[1]](diffhunk://#diff-0fd2d29168662b4fdd425dcafa2a6d90a35ee01c90f533e4126fe509b4390a89R891) [[2]](diffhunk://#diff-c5388a143ee9019b06a4a748d572eb6812fee7b59c185893bb6fdd2261cb2f9bR523)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Sonnet 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.