### PR TITLE
Fix static initialization memory problems in SignalHandler

### DIFF
--- a/src/SignalHandler.cc
+++ b/src/SignalHandler.cc
@@ -41,7 +41,8 @@ using namespace common;
 
 // Helper function to get signal wrappers map using NeverDestroyed pattern
 // to avoid static initialization order fiasco
-GZ_COMMON_VISIBLE std::map<int, std::function<void(int)>>& GetSignalWrappersInternal()
+GZ_COMMON_VISIBLE std::map<int, std::function<void(int)>>&
+GetSignalWrappersInternal()
 {
   static gz::utils::NeverDestroyed<
     std::map<int, std::function<void(int)>>> wrappers;
@@ -180,7 +181,7 @@ void SelfPipe::CheckPipe()
       {
         std::lock_guard<std::mutex> lock(GetWrapperMutexInternal());
         // Send the signal to each wrapper
-        for (std::pair<int, std::function<void(int)>> func : GetSignalWrappersInternal())
+        for (auto& func : GetSignalWrappersInternal())
         {
           func.second(signal);
         }

--- a/src/SignalHandler.cc
+++ b/src/SignalHandler.cc
@@ -34,14 +34,27 @@
 #include <vector> // NOLINT(*)
 #include "gz/common/Console.hh" // NOLINT(*)
 
+#include <gz/utils/NeverDestroyed.hh>
+
 using namespace gz;
 using namespace common;
 
-// A wrapper for the sigaction sa_handler.
-// TODO(azeey) We should avoid using objects with non-trivial destructors as
-// globals.
-GZ_COMMON_VISIBLE std::map<int, std::function<void(int)>> gOnSignalWrappers;
-std::mutex gWrapperMutex;
+// Helper function to get signal wrappers map using NeverDestroyed pattern
+// to avoid static initialization order fiasco
+GZ_COMMON_VISIBLE std::map<int, std::function<void(int)>>& GetSignalWrappersInternal()
+{
+  static gz::utils::NeverDestroyed<
+    std::map<int, std::function<void(int)>>> wrappers;
+  return wrappers.Access();
+}
+
+// Helper function to get wrapper mutex using NeverDestroyed pattern
+std::mutex& GetWrapperMutexInternal()
+{
+  static gz::utils::NeverDestroyed<std::mutex> mutex;
+  return mutex.Access();
+}
+
 
 #ifdef _WIN32
   #define write _write
@@ -165,9 +178,9 @@ void SelfPipe::CheckPipe()
     {
       if (this->running)
       {
-        std::lock_guard<std::mutex> lock(gWrapperMutex);
+        std::lock_guard<std::mutex> lock(GetWrapperMutexInternal());
         // Send the signal to each wrapper
-        for (std::pair<int, std::function<void(int)>> func : gOnSignalWrappers)
+        for (std::pair<int, std::function<void(int)>> func : GetSignalWrappersInternal())
         {
           func.second(signal);
         }
@@ -198,7 +211,7 @@ class common::SignalHandlerPrivate
   /// \brief True if signal handlers were successfully initialized.
   public: std::atomic<bool> initialized = {false};
 
-  /// \brief Index in the global gOnSignalWrappers map.
+  /// \brief Index in the global signal wrappers map.
   public: int wrapperIndex = -1;
 };
 
@@ -207,7 +220,7 @@ SignalHandler::SignalHandler()
   : dataPtr(new SignalHandlerPrivate)
 {
   static int counter = 0;
-  std::lock_guard<std::mutex> lock(gWrapperMutex);
+  std::lock_guard<std::mutex> lock(GetWrapperMutexInternal());
 
   SelfPipe::Initialize();
   if (std::signal(SIGINT, onSignalWriteToSelfPipe) == SIG_ERR)
@@ -224,7 +237,8 @@ SignalHandler::SignalHandler()
     return;
   }
 
-  gOnSignalWrappers[counter] = std::bind(&SignalHandlerPrivate::OnSignal,
+  GetSignalWrappersInternal()[counter] = std::bind(
+      &SignalHandlerPrivate::OnSignal,
       this->dataPtr, std::placeholders::_1);
   this->dataPtr->wrapperIndex = counter;
 
@@ -236,8 +250,8 @@ SignalHandler::SignalHandler()
 /////////////////////////////////////////////////
 SignalHandler::~SignalHandler()
 {
-  std::lock_guard<std::mutex> lock(gWrapperMutex);
-  gOnSignalWrappers.erase(this->dataPtr->wrapperIndex);
+  std::lock_guard<std::mutex> lock(GetWrapperMutexInternal());
+  GetSignalWrappersInternal().erase(this->dataPtr->wrapperIndex);
   delete this->dataPtr;
   this->dataPtr = nullptr;
 }

--- a/src/SignalHandler_TEST.cc
+++ b/src/SignalHandler_TEST.cc
@@ -261,11 +261,13 @@ TEST(SignalHandler, MultipleThreads)
   EXPECT_EQ(threadCount, static_cast<int>(threads.size()));
 
 #ifndef _WIN32
-  EXPECT_EQ(threadCount, static_cast<int>(GetSignalWrappersInternal().size()));
+  EXPECT_EQ(threadCount,
+            static_cast<int>(GetSignalWrappersInternal().size()));
 
-  // Check that all the indices in the signal wrappers map are increasing by one.
+  // Check that all the indices in the signal wrappers map are increasing
+  // by one.
   int index = GetSignalWrappersInternal().begin()->first;
-  for (std::pair<int, std::function<void(int)>> func : GetSignalWrappersInternal())
+  for (auto& func : GetSignalWrappersInternal())
   {
     EXPECT_EQ(index, func.first);
     ++index;

--- a/src/SignalHandler_TEST.cc
+++ b/src/SignalHandler_TEST.cc
@@ -29,9 +29,8 @@
 
 using namespace gz;
 
-// Capture the gOnSignalWrappers map from SignalHandlers.cc
 #ifndef _WIN32
-extern std::map<int, std::function<void(int)>> gOnSignalWrappers;
+extern std::map<int, std::function<void(int)>>& GetSignalWrappersInternal();
 #endif
 
 int gHandler1Sig = -1;
@@ -262,11 +261,11 @@ TEST(SignalHandler, MultipleThreads)
   EXPECT_EQ(threadCount, static_cast<int>(threads.size()));
 
 #ifndef _WIN32
-  EXPECT_EQ(threadCount, static_cast<int>(gOnSignalWrappers.size()));
+  EXPECT_EQ(threadCount, static_cast<int>(GetSignalWrappersInternal().size()));
 
-  // Check that all the indices in gOnSignalWrappers are increasing by one.
-  int index = gOnSignalWrappers.begin()->first;
-  for (std::pair<int, std::function<void(int)>> func : gOnSignalWrappers)
+  // Check that all the indices in the signal wrappers map are increasing by one.
+  int index = GetSignalWrappersInternal().begin()->first;
+  for (std::pair<int, std::function<void(int)>> func : GetSignalWrappersInternal())
   {
     EXPECT_EQ(index, func.first);
     ++index;


### PR DESCRIPTION
# 🦟 Bug fix

Part of #136 

## Summary

SignalHandler.cc — self-contained globals with non-trivial destructors                                                                                       

```c++                                                                                                                                                                                              
  // Translation unit: SignalHandler.cc                                                                                                                                                       
  GZ_COMMON_VISIBLE std::map<int, std::function<void(int)>> gOnSignalWrappers;                                  
  std::mutex gWrapperMutex;                                                                                                                                                                   
```
 
These are globals with non-trivial destructors. The problem could happen here probably at shutdown: SelfPipe (also a static inside SignalHandler.cc) spawns a thread in its constructor and joins it in its destructor. If gOnSignalWrappers or gWrapperMutex are destroyed before SelfPipe's thread finishes, the thread accesses already-destroyed objects. The TODO comment in the original code acknowledged this problem somehow.

Solution:

Changes defers construction to first use via function-local statics (thread-safe since C++11) and suppresses destructors at exit, eliminating undefined initialization and destruction order across translation units by wrapping global objects with gz::utils::NeverDestroyed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-By: Claude Sonnet 4.6