### PR TITLE
Change materials from static global to function-local static

### DIFF
--- a/include/gz/common/MaterialDensity.hh
+++ b/include/gz/common/MaterialDensity.hh
@@ -126,17 +126,6 @@ namespace gz
       /// \return The nearest material type. MATERIAL_TYPE_END on error.
       public: static Type NearestMaterial(const double _value,
                   const double _epsilon = std::numeric_limits<double>::max());
-
-#ifdef _WIN32
-// Disable warning C4251
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
-      /// \brief List of density entries
-      private: static std::map<Type, double> materials;
-#ifdef _WIN32
-#pragma warning(pop)
-#endif
     };
   }
 }

--- a/src/MaterialDensity.cc
+++ b/src/MaterialDensity.cc
@@ -19,6 +19,8 @@
 #include "gz/common/EnumIface.hh"
 #include "gz/common/MaterialDensity.hh"
 
+#include <gz/utils/NeverDestroyed.hh>
+
 using namespace gz;
 using namespace common;
 
@@ -44,30 +46,35 @@ GZ_ENUM(materialDensityIface, MaterialDensity::Type,
   "end"
 )
 
-// Initialize the materials
-std::map<MaterialDensity::Type, double> MaterialDensity::materials =
+// Helper function to get the materials map using NeverDestroyed pattern
+// to avoid static initialization order fiasco
+static std::map<MaterialDensity::Type, double>& GetMaterialsMap()
 {
-  {MaterialDensity::Type::STYROFOAM, 75.0},
-  {MaterialDensity::Type::PINE, 373.0},
-  {MaterialDensity::Type::WOOD, 700.0},
-  {MaterialDensity::Type::OAK, 710.0},
-  {MaterialDensity::Type::ICE, 916.0},
-  {MaterialDensity::Type::WATER, 1000.0},
-  {MaterialDensity::Type::PLASTIC, 1175.0},
-  {MaterialDensity::Type::CONCRETE, 2000.0},
-  {MaterialDensity::Type::ALUMINUM, 2700.0},
-  {MaterialDensity::Type::STEEL_ALLOY, 7600.0},
-  {MaterialDensity::Type::STEEL_STAINLESS, 7800.0},
-  {MaterialDensity::Type::IRON, 7870.0},
-  {MaterialDensity::Type::BRASS, 8600.0},
-  {MaterialDensity::Type::COPPER, 8940.0},
-  {MaterialDensity::Type::TUNGSTEN, 19300.0}
-};
+  static gz::utils::NeverDestroyed<std::map<MaterialDensity::Type, double>>
+    materials(std::map<MaterialDensity::Type, double>{
+      {MaterialDensity::Type::STYROFOAM, 75.0},
+      {MaterialDensity::Type::PINE, 373.0},
+      {MaterialDensity::Type::WOOD, 700.0},
+      {MaterialDensity::Type::OAK, 710.0},
+      {MaterialDensity::Type::ICE, 916.0},
+      {MaterialDensity::Type::WATER, 1000.0},
+      {MaterialDensity::Type::PLASTIC, 1175.0},
+      {MaterialDensity::Type::CONCRETE, 2000.0},
+      {MaterialDensity::Type::ALUMINUM, 2700.0},
+      {MaterialDensity::Type::STEEL_ALLOY, 7600.0},
+      {MaterialDensity::Type::STEEL_STAINLESS, 7800.0},
+      {MaterialDensity::Type::IRON, 7870.0},
+      {MaterialDensity::Type::BRASS, 8600.0},
+      {MaterialDensity::Type::COPPER, 8940.0},
+      {MaterialDensity::Type::TUNGSTEN, 19300.0}
+    });
+  return materials.Access();
+}
 
 /////////////////////////////////////////////////
 const std::map<MaterialDensity::Type, double> &MaterialDensity::Materials()
 {
-  return materials;
+  return GetMaterialsMap();
 }
 
 /////////////////////////////////////////////////
@@ -77,7 +84,7 @@ double MaterialDensity::Density(const std::string &_material)
   materialDensityIface.Set(type, _material);
 
   if (type != MaterialDensity::Type::END)
-    return materials[type];
+    return GetMaterialsMap()[type];
   else
     return -1;
 }
@@ -85,7 +92,7 @@ double MaterialDensity::Density(const std::string &_material)
 /////////////////////////////////////////////////
 double MaterialDensity::Density(const MaterialDensity::Type _material)
 {
-  return materials[_material];
+  return GetMaterialsMap()[_material];
 }
 
 /////////////////////////////////////////////////
@@ -98,7 +105,7 @@ std::tuple<MaterialDensity::Type, double> MaterialDensity::Nearest(
     MaterialDensity::Type::END, -1.0
   };
 
-  for (auto const &mat : materials)
+  for (auto const &mat : GetMaterialsMap())
   {
     double diff = std::fabs(mat.second - _value);
     if (diff < min && diff < _epsilon)


### PR DESCRIPTION
# 🦟 Bug fix

Part of #665 

## Summary
Replaced static class member materials map with NeverDestroyed-wrapped function-local GetMaterialsMap() to avoid problems with static initialization.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.