### PR TITLE
Fix SystemPaths_TEST in sandboxed builds

### DIFF
--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -346,7 +346,7 @@ TEST_F(SystemPathsFixture, FindFile)
 #ifndef _WIN32
   const auto tmpDir = "/tmp";
   const auto uriTmpDir = "file:///tmp";
-  const auto homeDir = "/home";
+  const auto homeDir = "/tmp";
   const auto badDir = "/bad";
   const auto uriBadDir = "file:///bad";
 #else

--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -378,28 +378,28 @@ TEST_F(SystemPathsFixture, FindFile)
 
   // Custom callback
   {
-    auto homeCb = [tmpDir](const std::string &_s)
+    auto tempCb = [tmpDir](const std::string &_s)
     {
-      return _s == "home" ? tmpDir : "";
+      return _s == "temp" ? tmpDir : "";
     };
     auto badCb = [badDir](const std::string &_s)
     {
       return _s == "bad" ? badDir : "";
     };
 
-    EXPECT_EQ("", sp.FindFile("home"));
+    EXPECT_EQ("", sp.FindFile("temp"));
     EXPECT_EQ("", sp.FindFile("bad"));
     EXPECT_EQ("", sp.FindFile("banana"));
 
-    sp.AddFindFileCallback(homeCb);
+    sp.AddFindFileCallback(tempCb);
 
-    EXPECT_EQ(tmpDir, sp.FindFile("home"));
+    EXPECT_EQ(tmpDir, sp.FindFile("temp"));
     EXPECT_EQ("", sp.FindFile("bad"));
     EXPECT_EQ("", sp.FindFile("banana"));
 
     sp.AddFindFileCallback(badCb);
 
-    EXPECT_EQ(tmpDir, sp.FindFile("home"));
+    EXPECT_EQ(tmpDir, sp.FindFile("temp"));
     EXPECT_EQ("", sp.FindFile("bad"));
     EXPECT_EQ("", sp.FindFile("banana"));
   }

--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -346,19 +346,17 @@ TEST_F(SystemPathsFixture, FindFile)
 #ifndef _WIN32
   const auto tmpDir = "/tmp";
   const auto uriTmpDir = "file:///tmp";
-  const auto homeDir = "/tmp";
   const auto badDir = "/bad";
   const auto uriBadDir = "file:///bad";
 #else
   const auto tmpDir = "C:\\Windows";
   const auto uriTmpDir = "file://C:/Windows";
-  const auto homeDir = "C:\\Users";
   const auto badDir = "C:\\bad";
   const auto uriBadDir = "file://C:/bad";
 #endif
   {
     EXPECT_EQ(tmpDir, sp.FindFile(uriTmpDir));
-    EXPECT_EQ(homeDir, sp.FindFile(homeDir));
+    EXPECT_EQ(tmpDir, sp.FindFile(tmpDir));
     EXPECT_EQ("", sp.FindFile(badDir));
     EXPECT_EQ("", sp.FindFile(uriBadDir));
   }
@@ -380,9 +378,9 @@ TEST_F(SystemPathsFixture, FindFile)
 
   // Custom callback
   {
-    auto homeCb = [homeDir](const std::string &_s)
+    auto homeCb = [tmpDir](const std::string &_s)
     {
-      return _s == "home" ? homeDir : "";
+      return _s == "home" ? tmpDir : "";
     };
     auto badCb = [badDir](const std::string &_s)
     {
@@ -395,13 +393,13 @@ TEST_F(SystemPathsFixture, FindFile)
 
     sp.AddFindFileCallback(homeCb);
 
-    EXPECT_EQ(homeDir, sp.FindFile("home"));
+    EXPECT_EQ(tmpDir, sp.FindFile("home"));
     EXPECT_EQ("", sp.FindFile("bad"));
     EXPECT_EQ("", sp.FindFile("banana"));
 
     sp.AddFindFileCallback(badCb);
 
-    EXPECT_EQ(homeDir, sp.FindFile("home"));
+    EXPECT_EQ(tmpDir, sp.FindFile("home"));
     EXPECT_EQ("", sp.FindFile("bad"));
     EXPECT_EQ("", sp.FindFile("banana"));
   }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Replace hardcoded `/home` with `/tmp` in `SystemPaths_TEST.cc` `FindFile` test.

The `/home` directory does not exist in all environments (e.g. sandboxed builds, minimal containers), causing `SystemPaths_TEST` to fail. `/tmp` is guaranteed to exist on POSIX systems and is already used elsewhere in the same test.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.