### PR TITLE
Prepare for 7.2.0~pre1 prerelease

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common VERSION 7.1.1)
+project(gz-common VERSION 7.2.0)
 
 #============================================================================
 # Find gz-cmake
@@ -16,7 +16,7 @@ find_package(gz-cmake 5 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common</name>
-  <version>7.1.1</version>
+  <version>7.2.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎈 Release

Preparation for 7.2.0~pre1 prerelease.

As discussed in https://github.com/gazebosim/gz-common/pull/803#issuecomment-4329465395, we have merged #803 (backport of #725) and are creating this prerelease to support testing.

Comparison to 7.1.1: https://github.com/gazebosim/gz-common/compare/gz-common7_7.1.1...scpeters/prepare_7.2.0?expand=1

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
