### PR TITLE
Use SYSTEM when include gdal headers

### DIFF
--- a/geospatial/src/CMakeLists.txt
+++ b/geospatial/src/CMakeLists.txt
@@ -14,6 +14,7 @@ if (TARGET ${PROJECT_LIBRARY_TARGET_NAME}-graphics)
       ${GDAL_LIBRARY})
 
   target_include_directories(${geospatial_target}
+    SYSTEM
     PRIVATE
       ${GDAL_INCLUDE_DIR})
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compiler warnings on 26.04, part of https://github.com/gazebo-tooling/release-tools/issues/1485

## Summary

There are currently 10 compiler warnings from gdal headers on 26.04:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-ci-main-resolute-amd64&build=1)](https://build.osrfoundation.org/job/gz_common-ci-main-resolute-amd64/1/) https://build.osrfoundation.org/job/gz_common-ci-main-resolute-amd64/1/gcc/

Adding the `SYSTEM` keyword to `target_include_directories` suppresses any compiler warnings from those headers (see [log of Ubuntu Resolute CI](https://github.com/gazebosim/gz-common/actions/runs/25721709137/job/75524247528?pr=813#step:4:12628)).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
