### PR TITLE
Fixes for ASAN problems

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -218,6 +218,19 @@ bool AudioDecoder::SetFile(const std::string &_filename)
 {
   unsigned int i;
 
+  // Release any context allocated by a previous SetFile call
+  if (this->dataPtr->codecCtx)
+  {
+#if LIBAVFORMAT_VERSION_MAJOR < 59
+    avcodec_close(this->dataPtr->codecCtx);
+#else
+    avcodec_free_context(&this->dataPtr->codecCtx);
+#endif
+  }
+  if (this->dataPtr->formatCtx)
+    avformat_close_input(&this->dataPtr->formatCtx);
+  this->dataPtr->codec = nullptr;
+
   this->dataPtr->formatCtx = avformat_alloc_context();
 
   // Open file

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -107,8 +107,8 @@ Video::~Video()
 /////////////////////////////////////////////////
 void Video::Cleanup()
 {
-  // Free the YUV frame
-  av_free(this->dataPtr->avFrame);
+  // Free the YUV frame (and any reference-counted side data)
+  av_frame_free(&this->dataPtr->avFrame);
 
   // Close the video file
   avformat_close_input(&this->dataPtr->formatCtx);
@@ -120,7 +120,13 @@ void Video::Cleanup()
   avcodec_close(this->dataPtr->codecCtx);
 #endif
 
-  av_free(this->dataPtr->avFrameDst);
+  av_frame_free(&this->dataPtr->avFrameDst);
+
+  if (this->dataPtr->swsCtx)
+  {
+    sws_freeContext(this->dataPtr->swsCtx);
+    this->dataPtr->swsCtx = nullptr;
+  }
 }
 
 /////////////////////////////////////////////////
@@ -261,19 +267,18 @@ bool Video::Load(const std::string &_filename)
 /////////////////////////////////////////////////
 bool Video::NextFrame(unsigned char **_buffer)
 {
-  AVPacket* packet;
   int frameAvailable = 0;
   int ret;
 
+  AVPacket* packet = av_packet_alloc();
+  if (!packet)
+  {
+    gzerr << "Failed to allocate AVPacket" << std::endl;
+    return false;
+  }
+
   while (frameAvailable == 0)
   {
-    packet = av_packet_alloc();
-    if (!packet)
-    {
-      gzerr << "Failed to allocate AVPacket" << std::endl;
-      return false;
-    }
-
     // this loop will always exit because each call to AVCodecDecode()
     // reads from the input buffer and it has to either end at some time or
     // return a valid frame
@@ -295,6 +300,7 @@ bool Video::NextFrame(unsigned char **_buffer)
         {
           gzerr << "Error reading packet: " << av_err2str_cpp(ret)
                  << ". Stopped reading the file." << std::endl;
+          av_packet_free(&packet);
           return false;
         }
       }
@@ -315,6 +321,7 @@ bool Video::NextFrame(unsigned char **_buffer)
     {
       if (!this->dataPtr->drainingMode)
         av_packet_unref(packet);
+      av_packet_free(&packet);
       return false;
     }
     else if (ret < 0)
@@ -326,6 +333,8 @@ bool Video::NextFrame(unsigned char **_buffer)
     if (!this->dataPtr->drainingMode)
       av_packet_unref(packet);
   }
+
+  av_packet_free(&packet);
 
   // processing the image if available
   if (frameAvailable)

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -713,6 +713,13 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
 
   int ret = 0;
 
+  AVPacket* avPacket = av_packet_alloc();
+  if (!avPacket)
+  {
+    gzerr << "Failed to allocate AVPacket" << std::endl;
+    return false;
+  }
+
   // make sure we have continuous pts (frame number) otherwise some decoders
   // may not be happy. So encode more (duplicate) frames until the current frame
   // number
@@ -721,8 +728,6 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
        ++i)
   {
     frameToEncode->pts = this->dataPtr->frameCount++;
-
-    AVPacket* avPacket = av_packet_alloc();
 
     avPacket->data = nullptr;
     avPacket->size = 0;
@@ -743,6 +748,8 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
 
     av_packet_unref(avPacket);
   }
+
+  av_packet_free(&avPacket);
   return ret >= 0 || ret == AVERROR(EAGAIN);
 }
 

--- a/src/EnumIface_TEST.cc
+++ b/src/EnumIface_TEST.cc
@@ -25,7 +25,7 @@ using namespace gz;
 
 class EnumIfaceTest : public common::testing::AutoLogFixture { };
 
-enum MyType
+enum MyType : int
 {
   MY_TYPE_BEGIN = 0,
   TYPE1 = MY_TYPE_BEGIN,


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-common/issues/665

## Summary

Using the AI agent to fix the memory problems. I've reviewed the commits, all are good to my eyes:

Per commit fixes explained:

11034a3 test: give MyType a fixed underlying type to fix UBSan -fsanitize=enum:
The test casts `4` to `MyType` to verify `Str()` returns empty for an   invalid enum. With no fixed underlying type, the cast is UB ([expr.static.cast]).   Pinning to `int` makes the cast well-defined; test semantics unchanged. 


eb3ee50  Audio: release prior contexts when SetFile is called more than once:
`SetFile()` re-allocated `formatCtx` /  codecCtx` without freeing the previous ones — leaks the entire context for every file but the last on the WAV→OGG→MP3 path. LSan: 164 allocs / 437 kB. Cleanup at the top of `SetFile` mirrors the destructor.

9129a7b  Video: fix per-frame AVPacket leak and Cleanup() resource leaks ()  
`NextFrame()` paired `av_packet_alloc()` with `av_packet_unref()` (which  doesn't free the struct) — per-frame leak. `Cleanup()` used `av_free()`  on `AVFrame*` (leaks side data) and never released `swsCtx`. LSan:  290 allocs / 549 kB. Hosts the packet, switches to `av_frame_free()` /`sws_freeContext()`.

ce2055b `VideoEncoder: free AVPacket struct in AddFrame() encode loop` 
Same `av_packet_alloc()` / `av_packet_unref()` mismatch as #3, in `AddFrame()`'s encode loop. LSan: 258 allocs / 203 kB. `Stop()` in the same file already had the correct pattern; `AddFrame()` now matches.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.