### PR TITLE
Remotery: free entire sample tree on destruction to fix leak

### DIFF
--- a/profiler/src/Remotery/lib/Remotery.c
+++ b/profiler/src/Remotery/lib/Remotery.c
@@ -4927,13 +4927,25 @@ static rmtError SampleTree_Constructor(SampleTree* tree, rmtU32 sample_size, Obj
     return RMT_ERROR_NONE;
 }
 
+// gz-common: forward declaration so SampleTree_Destructor can release the
+// whole tree (root + descendants), see leak fix below. FreeSamples is defined
+// further down in this file.
+static void FreeSamples(Sample* sample, ObjectAllocator* allocator);
+
 static void SampleTree_Destructor(SampleTree* tree)
 {
     assert(tree != NULL);
 
+    // gz-common ASAN fix: free the entire sample tree, not just the root.
+    // Persistent samples (e.g. the aggregate samples the Remotery worker thread
+    // creates while profiling its own loop) accumulate as children of the root
+    // and are never returned to the allocator's free list. ObjectAllocator's
+    // destructor only frees objects on that free list, so those orphaned child
+    // samples were leaked at shutdown. FreeSamples() flattens root and all of
+    // its descendants back into the allocator before it is destroyed.
     if (tree->root != NULL)
     {
-        ObjectAllocator_Free(tree->allocator, tree->root);
+        FreeSamples(tree->root, tree->allocator);
         tree->root = NULL;
     }
 


### PR DESCRIPTION
## 🦟 Description

Fixes the last remaining ASAN/LeakSanitizer failure in `UNIT_Profiler_Remotery_TEST` (336 bytes leaked in 3 indirect allocations), following the earlier ASAN cleanup work in #814.

### Root cause

The leak is in the vendored Remotery library. Its background worker thread (`Remotery_ThreadMain`) profiles its own loop each iteration:

```c
rmt_BeginCPUSample(Wakeup, 0);                 // Remotery.c:6917
  rmt_BeginCPUSample(ServerUpdate, 0);         // :6919
  rmt_BeginCPUSample(ConsumeMessageQueue, 0);  // :6923
```

These three persistent aggregate samples accumulate as **children of the thread's root sample**. At shutdown, `SampleTree_Destructor` returned only the *root* node to its `ObjectAllocator`. The allocator's destructor frees only objects on its free list, so the orphaned child samples were never freed — reported by LeakSanitizer as indirect leaks. (An `assert(nb_inuse == 0)` would have caught this, but asserts are compiled out in the release ASAN build.)

### Fix

Free the entire tree via the existing `FreeSamples()` helper, which flattens the root plus all descendants back into the allocator before it is destroyed. This matches how every other sample-tree teardown path in Remotery already releases its samples. A forward declaration is added since `FreeSamples` is defined later in the file.

The change is a local patch to the vendored `Remotery.c`, consistent with existing precedent (e.g. 36afa7a).

## 🧪 Test it

Built with `GZ_SANITIZER=Address` and ran the test:

- **Before:** `SUMMARY: AddressSanitizer: 336 byte(s) leaked in 3 allocation(s)` — FAILED
- **After:** PASSES, exit 0, no LeakSanitizer report

`UNIT_Profiler_Error_TEST` and `UNIT_Profiler_Disabled_TEST` (which share the destructor path) still pass clean under ASAN.

## Checklist
- [x] Signed all commits for DCO
- [x] No new ABI changes (local C source change, no public API)
- [x] All tests passing under ASAN

Generated-by: Claude Opus 4.8