### PR TITLE
Fix flakiness in PluginSpecialization.AccessTime performance test

### DIFF
--- a/test/performance/plugin_specialization.cc
+++ b/test/performance/plugin_specialization.cc
@@ -205,14 +205,16 @@ TEST(PluginSpecialization, AccessTime)
     }
   }
 
-  // Test that none of the specialized results are double the baseline (or
-  // vice-versa)
+  // Test that none of the specialized results are drastically slower than the
+  // baseline (e.g. within a factor of 4). This verifies O(1) scaling while
+  // allowing for minor micro-architectural overheads (like vtable lookups).
   const double baseline = tests[1].avg;
-  EXPECT_LT(std::abs(tests[2].avg - baseline), baseline);
-  EXPECT_LT(std::abs(tests[3].avg - baseline), baseline);
-  EXPECT_LT(std::abs(tests[4].avg - baseline), baseline);
-  EXPECT_LT(std::abs(tests[5].avg - baseline), baseline);
-  EXPECT_LT(std::abs(tests[6].avg - baseline), baseline);
+  const double tolerance = 3.0 * baseline;
+  EXPECT_LT(std::abs(tests[2].avg - baseline), tolerance);
+  EXPECT_LT(std::abs(tests[3].avg - baseline), tolerance);
+  EXPECT_LT(std::abs(tests[4].avg - baseline), tolerance);
+  EXPECT_LT(std::abs(tests[5].avg - baseline), tolerance);
+  EXPECT_LT(std::abs(tests[6].avg - baseline), tolerance);
 
   // Test that the specialized results are always better than the generic result
   EXPECT_LT(tests[0].avg, tests.back().avg);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #819

## Summary
Relax the performance assertion threshold to 4x (tolerance = 3.0 * baseline) to prevent flakiness due to micro-architectural differences in vtable offset lookups.

Note that this test and the associated code it's testing was moved to gz-plugin (see https://github.com/gazebosim/gz-common/pull/433), so this PR targets gz-common5 and should be backported to Fortress.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
