### PR TITLE
Change STLLoader to assign name to submesh 

### DIFF
--- a/graphics/src/STLLoader.cc
+++ b/graphics/src/STLLoader.cc
@@ -99,6 +99,7 @@ bool STLLoader::ReadAscii(FILE *_filein, Mesh *_mesh)
   int width;
   char input[LINE_MAX_LEN];
   bool result = true;
+  char name[LINE_MAX_LEN];
 
   SubMesh subMesh;
 
@@ -174,10 +175,20 @@ bool STLLoader::ReadAscii(FILE *_filein, Mesh *_mesh)
     // SOLID
     else if (this->Leqi (token, const_cast<char*>("solid")))
     {
+      sscanf(next, "%s", name);
     }
     // ENDSOLID
     else if (this->Leqi (token, const_cast<char*>("endsolid")))
     {
+      // warn if name after 'endsolid 'is different from name after 'solid'
+      char endSolidName[LINE_MAX_LEN];
+      sscanf(next, "%s", endSolidName);
+
+      if (strcmp(endSolidName, name) != 0)
+      {
+        gzwarn << "End solid name: [" << endSolidName << \
+        "] is not the same as solid name [" << name << "]\n";
+      }
     }
     // Unexpected or unrecognized.
     else
@@ -194,7 +205,11 @@ bool STLLoader::ReadAscii(FILE *_filein, Mesh *_mesh)
   result = subMesh.VertexCount() > 0;
 
   if (result)
+  {
+    std::string meshName(name);
+    subMesh.SetName(meshName);
     _mesh->AddSubMesh(subMesh);
+  }
 
   return result;
 }

--- a/graphics/src/STLLoader.cc
+++ b/graphics/src/STLLoader.cc
@@ -99,7 +99,7 @@ bool STLLoader::ReadAscii(FILE *_filein, Mesh *_mesh)
   int width;
   char input[LINE_MAX_LEN];
   bool result = true;
-  char name[LINE_MAX_LEN];
+  char name[LINE_MAX_LEN] = "";
 
   SubMesh subMesh;
 
@@ -181,7 +181,7 @@ bool STLLoader::ReadAscii(FILE *_filein, Mesh *_mesh)
     else if (this->Leqi (token, const_cast<char*>("endsolid")))
     {
       // warn if name after 'endsolid 'is different from name after 'solid'
-      char endSolidName[LINE_MAX_LEN];
+      char endSolidName[LINE_MAX_LEN] = "";
       sscanf(next, "%s", endSolidName);
 
       if (strcmp(endSolidName, name) != 0)

--- a/graphics/src/STLLoader_TEST.cc
+++ b/graphics/src/STLLoader_TEST.cc
@@ -65,7 +65,7 @@ TEST_F(STLLoaderTest, LoadSTL)
   for (unsigned int i = 0; i < subMesh->IndexCount(); ++i)
     EXPECT_EQ(i, static_cast<unsigned int>(subMesh->Index(i)));
 
-  EXPECT_STREQ("", mesh->SubMeshByIndex(0).lock()->Name().c_str());
+  EXPECT_STREQ("model", mesh->SubMeshByIndex(0).lock()->Name().c_str());
   delete mesh;
 
   mesh = loader.Load(


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While testing how AssimpLoader compares to other loaders (like STLLoader), we noticed that the AssimpLoader assigns a name to the submesh according to this convention ([wikipedia link](https://en.wikipedia.org/wiki/STL_(file_format)#ASCII)) while our custom STLLoader does not. 

Thus, when trying to port the STL tests to AssimpLoader [this line](https://github.com/gazebosim/gz-common/blob/843fc9f2961ab3478ab2757513fb749fdf9445b9/graphics/src/STLLoader_TEST.cc#L68) 
```
EXPECT_STREQ("", mesh->SubMeshByIndex(0).lock()->Name().c_str());
```
fails for the AssimpLoader because the submesh name is assigned to be [`model`](https://github.com/gazebosim/gz-common/blob/843fc9f2961ab3478ab2757513fb749fdf9445b9/test/data/cube.stl#L1) and not an empty string. 

This PR updates the STLLoader test to expect a name and also updates the behaviour of the STLLoader to assign a name to the submesh. 

## Test it
1. Build workspace 
2. `cd build/gz-common`
3. `ctest -R "STL" --output-on-failure` 

Edited the test in 0801672 (CI fails) and the fix in 2453b83 (CI green)

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [X] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸