### PR TITLE
Prepare for 7.2.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(gz-cmake 5 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,28 @@
 ## Gazebo Common 7.x
 
+### Gazebo Common 7.2.0 (2026-07-10)
+
+1. [bazel] Bump default bazel version to 9.1.1 and bump CI workflow version (backport #840)
+    * [Pull request #841](https://github.com/gazebosim/gz-common/pull/841)
+
+1. Improve performance on STL loader (ASCII)
+    * [Pull request #833](https://github.com/gazebosim/gz-common/pull/833)
+
+1. macos CI: use brew trust
+    * [Pull request #827](https://github.com/gazebosim/gz-common/pull/827)
+
+1. Fix SystemPaths_TEST in sandboxed builds
+    * [Pull request #806](https://github.com/gazebosim/gz-common/pull/806)
+
+1. Replace FreeImage dependency with stb
+    * [Pull request #803](https://github.com/gazebosim/gz-common/pull/803)
+
+1. [bazel/infra] Minimize manual steps in publish to BCR workflow
+    * [Pull request #786](https://github.com/gazebosim/gz-common/pull/786)
+
+1. Refactor `RedirectConsoleStream` to use portable C++ stream buffer redirection
+    * [Pull request #785](https://github.com/gazebosim/gz-common/pull/785)
+
 ### Gazebo Common 7.1.1 (2026-02-25)
 
 1. graphics: Optimize Texture Processing and Memory in AssimpLoader


### PR DESCRIPTION

# 🎈 Release

Preparation for 7.2.0 release.

Comparison to 7.1.1: https://github.com/gazebosim/gz-common/compare/gz-common7_7.1.1...prep_7.2.0

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
