### PR TITLE
Minor AssimpLoader changes

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -35,9 +35,7 @@
 #include "gz/common/SystemPaths.hh"
 #include "gz/common/Util.hh"
 
-#ifndef GZ_ASSIMP_PRE_5_2_0
-  #include <assimp/GltfMaterial.h>    // GLTF specific material properties
-#endif
+#include <assimp/GltfMaterial.h>    // GLTF specific material properties
 #include <assimp/Importer.hpp>      // C++ importer interface
 #include <assimp/postprocess.h>     // Post processing flags
 #include <assimp/scene.h>           // Output data structure
@@ -407,7 +405,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     mat->SetBlendFactors(opacity, 1.0 - opacity);
   }
 
-#ifndef GZ_ASSIMP_PRE_5_1_0
   // basic support for transmission - currently just overrides opacity
   // \todo(iche033) The transmission factor can be used with volume
   // material extension to simulate effects like refraction
@@ -419,7 +416,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   {
     mat->SetTransparency(transmission);
   }
-#endif
 
   // TODO(luca) more than one texture, Gazebo assumes UV index 0
   Pbr pbr;
@@ -435,7 +431,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Diffuse"));
     mat->SetTextureImage(texName, texData);
-#ifndef GZ_ASSIMP_PRE_5_2_0
     // Now set the alpha from texture, if enabled, only supported in GLTF
     aiString alphaMode;
     auto paramRet = assimpMat->Get(AI_MATKEY_GLTF_ALPHAMODE, alphaMode);
@@ -452,9 +447,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
         mat->SetAlphaFromTexture(true, alphaCutoff, twoSided);
       }
     }
-#endif
   }
-#ifndef GZ_ASSIMP_PRE_5_2_0
   // Edge case for GLTF, Metal and Rough texture are embedded in a
   // MetallicRoughness texture with metalness in B and roughness in G
   // Open, preprocess and split into metal and roughness map
@@ -583,7 +576,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       }
     }
   }
-#endif
   ret = assimpMat->GetTexture(aiTextureType_NORMALS, 0, &texturePath);
   if (ret == AI_SUCCESS)
   {
@@ -601,7 +593,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Emissive"));
     pbr.SetEmissiveMap(texName, texData);
   }
-#ifndef GZ_ASSIMP_PRE_5_2_0
   float value;
   ret = assimpMat->Get(AI_MATKEY_METALLIC_FACTOR, value);
   if (ret == AI_SUCCESS)
@@ -617,7 +608,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   {
     pbr.SetRoughness(value);
   }
-#endif
   mat->SetPbrMaterial(pbr);
   return mat;
 }
@@ -829,9 +819,7 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
       aiProcess_RemoveRedundantMaterials |
       aiProcess_SortByPType |
       aiProcess_FlipUVs |
-#ifndef GZ_ASSIMP_PRE_5_2_0
       aiProcess_PopulateArmatureData |
-#endif
       aiProcess_Triangulate |
       aiProcess_GenNormals |
       0);

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -848,6 +848,15 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
   // Add the materials first
   for (unsigned _matIdx = 0; _matIdx < scene->mNumMaterials; ++_matIdx)
   {
+    aiString matName;
+    if (scene->mNumMaterials == 1 &&
+      AI_SUCCESS == scene->mMaterials[_matIdx]->Get(AI_MATKEY_NAME, matName) &&
+      std::string(matName.C_Str()) == AI_DEFAULT_MATERIAL_NAME)
+    {
+      // If there's only 1 material and it's Assimp's default, skip adding it.
+      continue;
+    }
+
     auto mat = this->dataPtr->CreateMaterial(scene, _matIdx, path);
     mesh->AddMaterial(mat);
   }

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -840,7 +840,7 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
       extension.begin(), ::tolower);
 
   // compute assimp root node transform
-  bool useIdentityRotation = (extension != "glb" && extension != "glTF");
+  bool useIdentityRotation = (extension != "glb" && extension != "gltf");
   auto transform = this->dataPtr->UpdatedRootNodeTransform(scene,
     useIdentityRotation);
   auto rootTransform = this->dataPtr->ConvertTransform(transform);

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -83,13 +83,15 @@ class AssimpLoader::Implementation
   /// \param[in] _scene the assimp scene
   /// \param[in] _matIdx index of the material in the scene
   /// \param[in] _path path where the mesh is located
-  /// \return pointer to the converted common::Material
+  /// \return pointer to the converted common::Material, nullptr if the material
+  /// was default created by assimp
   public: MaterialPtr CreateMaterial(const aiScene *_scene,
                                      unsigned _matIdx,
                                      const std::string &_path) const;
 
   /// \brief Check if Assimp material was default created by assimp
   /// \param[in] _assimpMat the assimp material
+  /// \return whether the material was default created by assimp
   public: bool IsDefaultMaterial(const aiMaterial* _assimpMat) const;
 
   /// \brief Load a texture embedded in a mesh (i.e. for GLB format)

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -367,8 +367,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   MaterialPtr mat = std::make_shared<Material>();
   aiColor4D color;
   bool specularDefine = false;
-  // gcc is complaining about this variable not being used.
-  (void) specularDefine;
   auto& assimpMat = _scene->mMaterials[_matIdx];
   auto ret = assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, color);
   if (ret == AI_SUCCESS)

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -88,6 +88,10 @@ class AssimpLoader::Implementation
                                      unsigned _matIdx,
                                      const std::string &_path) const;
 
+  /// \brief Check if Assimp material was default created by assimp
+  /// \param[in] _assimpMat the assimp material
+  public: bool IsDefaultMaterial(const aiMaterial* _assimpMat) const;
+
   /// \brief Load a texture embedded in a mesh (i.e. for GLB format)
   /// into a gz::common::Image
   /// \param[in] _texture the assimp texture object
@@ -368,6 +372,11 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   aiColor4D color;
   bool specularDefine = false;
   auto& assimpMat = _scene->mMaterials[_matIdx];
+  bool defaultMaterial = IsDefaultMaterial(assimpMat);
+  if (defaultMaterial)
+  {
+    return nullptr;
+  }
   auto ret = assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, color);
   if (ret == AI_SUCCESS)
   {
@@ -793,6 +802,23 @@ SubMesh AssimpLoader::Implementation::CreateSubMesh(
 }
 
 //////////////////////////////////////////////////
+bool AssimpLoader::Implementation::IsDefaultMaterial(
+    const aiMaterial* _assimpMat) const
+{
+  aiString matName;
+  aiColor3D clr;
+  _assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, clr);
+
+  if ((_assimpMat->Get(AI_MATKEY_NAME, matName) == AI_SUCCESS) &&
+      (ToString(matName) == AI_DEFAULT_MATERIAL_NAME) &&
+      (_assimpMat->mNumProperties == 2))
+  {
+    return true;
+  }
+  return false;
+}
+
+//////////////////////////////////////////////////
 AssimpLoader::AssimpLoader()
 : MeshLoader(), dataPtr(utils::MakeUniqueImpl<Implementation>())
 {
@@ -846,15 +872,6 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
   // Add the materials first
   for (unsigned _matIdx = 0; _matIdx < scene->mNumMaterials; ++_matIdx)
   {
-    aiString matName;
-    if (scene->mNumMaterials == 1 &&
-      AI_SUCCESS == scene->mMaterials[_matIdx]->Get(AI_MATKEY_NAME, matName) &&
-      std::string(matName.C_Str()) == AI_DEFAULT_MATERIAL_NAME)
-    {
-      // If there's only 1 material and it's Assimp's default, skip adding it.
-      continue;
-    }
-
     auto mat = this->dataPtr->CreateMaterial(scene, _matIdx, path);
     mesh->AddMaterial(mat);
   }

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -372,8 +372,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   aiColor4D color;
   bool specularDefine = false;
   auto& assimpMat = _scene->mMaterials[_matIdx];
-  bool defaultMaterial = IsDefaultMaterial(assimpMat);
-  if (defaultMaterial)
+  if (IsDefaultMaterial(assimpMat))
   {
     return nullptr;
   }
@@ -806,9 +805,6 @@ bool AssimpLoader::Implementation::IsDefaultMaterial(
     const aiMaterial* _assimpMat) const
 {
   aiString matName;
-  aiColor3D clr;
-  _assimpMat->Get(AI_MATKEY_COLOR_DIFFUSE, clr);
-
   if ((_assimpMat->Get(AI_MATKEY_NAME, matName) == AI_SUCCESS) &&
       (ToString(matName) == AI_DEFAULT_MATERIAL_NAME) &&
       (_assimpMat->mNumProperties == 2))

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -259,8 +259,6 @@ TEST_F(AssimpLoader, TexCoordSets)
   delete mesh;
 }
 
-// Test fails for assimp below 5.2.0
-#ifndef GZ_ASSIMP_PRE_5_2_0
 /////////////////////////////////////////////////
 TEST_F(AssimpLoader, LoadBoxWithAnimationOutsideSkeleton)
 {
@@ -297,7 +295,6 @@ TEST_F(AssimpLoader, LoadBoxWithAnimationOutsideSkeleton)
   EXPECT_EQ(expectedTrans, poseEnd.at("Armature"));
   delete mesh;
 }
-#endif
 
 /////////////////////////////////////////////////
 TEST_F(AssimpLoader, LoadBoxInstControllerWithoutSkeleton)
@@ -464,9 +461,6 @@ TEST_F(AssimpLoader, MergeBoxWithDoubleSkeleton)
   delete mesh;
 }
 
-// For assimp below 5.2.0 mesh loading fails because of
-// failing to parse the empty <author> tag
-#ifndef GZ_ASSIMP_PRE_5_2_0
 /////////////////////////////////////////////////
 TEST_F(AssimpLoader, LoadCylinderAnimatedFrom3dsMax)
 {
@@ -503,7 +497,6 @@ TEST_F(AssimpLoader, LoadCylinderAnimatedFrom3dsMax)
   EXPECT_TRUE(anim->HasNode("Bone02"));
   delete mesh;
 }
-#endif
 
 /////////////////////////////////////////////////
 TEST_F(AssimpLoader, LoadObjBox)
@@ -669,7 +662,6 @@ TEST_F(AssimpLoader, LoadGlTF2BoxExternalTexture)
 // Open a gltf mesh with transmission extension
 TEST_F(AssimpLoader, LoadGlTF2BoxTransmission)
 {
-#ifndef GZ_ASSIMP_PRE_5_1_0
   common::AssimpLoader loader;
   common::Mesh *mesh = loader.Load(
       common::testing::TestFile("data", "box_transmission.glb"));
@@ -686,7 +678,6 @@ TEST_F(AssimpLoader, LoadGlTF2BoxTransmission)
   // transmission currently modeled as transparency
   EXPECT_FLOAT_EQ(0.1f, mat->Transparency());
   delete mesh;
-#endif
 }
 
 /////////////////////////////////////////////////
@@ -778,7 +769,6 @@ TEST_F(AssimpLoader, LoadGlbPbrAsset)
 
   EXPECT_NE(pbr->NormalMapData(), nullptr);
   // Metallic roughness and alpha from textures only works in assimp > 5.2.0
-#ifndef GZ_ASSIMP_PRE_5_2_0
   // Alpha from textures
   EXPECT_TRUE(material->TextureAlphaEnabled());
   EXPECT_TRUE(material->TwoSidedEnabled());
@@ -795,7 +785,6 @@ TEST_F(AssimpLoader, LoadGlbPbrAsset)
   // \todo(iche033) Lightmaps are disabled for glb meshes
   // due to upstream bug
   // EXPECT_EQ(pbr->LightMapTexCoordSet(), 1);
-#endif
 
   // \todo(iche033) Lightmaps are disabled for glb meshes
   // due to upstream bug

--- a/graphics/src/AssimpLoader_TEST.cc
+++ b/graphics/src/AssimpLoader_TEST.cc
@@ -187,7 +187,7 @@ TEST_F(AssimpLoader, TexCoordSets)
   EXPECT_EQ(6u, mesh->IndexCount());
   EXPECT_EQ(6u, mesh->TexCoordCount());
   EXPECT_EQ(2u, mesh->SubMeshCount());
-  EXPECT_EQ(1u, mesh->MaterialCount());
+  EXPECT_EQ(0u, mesh->MaterialCount());
 
   auto sm = mesh->SubMeshByIndex(0u);
   auto subMesh = sm.lock();
@@ -411,7 +411,7 @@ TEST_F(AssimpLoader, LoadBoxWithMultipleGeoms)
 
   EXPECT_EQ(72u, mesh->IndexCount());
   EXPECT_EQ(48u, mesh->VertexCount());
-  EXPECT_EQ(1u, mesh->MaterialCount());
+  EXPECT_EQ(0u, mesh->MaterialCount());
   EXPECT_EQ(48u, mesh->TexCoordCount());
   ASSERT_EQ(1u, mesh->MeshSkeleton()->AnimationCount());
   ASSERT_EQ(2u, mesh->SubMeshCount());
@@ -477,7 +477,7 @@ TEST_F(AssimpLoader, LoadCylinderAnimatedFrom3dsMax)
   EXPECT_EQ(194u, mesh->NormalCount());
   EXPECT_EQ(852u, mesh->IndexCount());
   EXPECT_LT(0u, mesh->TexCoordCount());
-  EXPECT_EQ(1u, mesh->MaterialCount());
+  EXPECT_EQ(0u, mesh->MaterialCount());
 
   EXPECT_EQ(1u, mesh->SubMeshCount());
   auto subMesh = mesh->SubMeshByIndex(0);

--- a/graphics/src/CMakeLists.txt
+++ b/graphics/src/CMakeLists.txt
@@ -25,20 +25,3 @@ gz_build_tests(
     gz-common-testing
     TINYXML2::TINYXML2
 )
-
-# Assimp doesn't offer preprocessor version, use cmake to set a compatibility
-# mode for versions below 5.2.0 and 5.1.0
-if(${GzAssimp_VERSION} STRLESS "5.2.0")
-  message("Warning, assimp below 5.2.0 detected, setting compatibility mode")
-  target_compile_definitions(${graphics_target} PRIVATE GZ_ASSIMP_PRE_5_2_0)
-  if(TARGET UNIT_AssimpLoader_TEST)
-    target_compile_definitions(UNIT_AssimpLoader_TEST PRIVATE GZ_ASSIMP_PRE_5_2_0)
-  endif()
-  if(${GzAssimp_VERSION} STRLESS "5.1.0")
-    message("Warning, assimp below 5.1.0 detected, setting compatibility mode")
-    target_compile_definitions(${graphics_target} PRIVATE GZ_ASSIMP_PRE_5_1_0)
-    if(TARGET UNIT_AssimpLoader_TEST)
-      target_compile_definitions(UNIT_AssimpLoader_TEST PRIVATE GZ_ASSIMP_PRE_5_1_0)
-    endif()
-  endif()
-endif()


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

More minor fixes/changes to AssimpLoader (from #844)

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

1. Remove ifdefs 
2. Do not create a material if it was just a default by assimp
Assimp creates a material for every mesh, but some meshes do not have any material information. So tests where there is an expectation for 0 materials will fail. I added logic to check if the name of the assimp material has the default AI_DEFAULT_MATERIAL_NAME name and to skip creating a material if it is to restore the old behavior.
3. Fix rotation for gltf
Referring to the images in #543 where this logic was introduced, the [BarramundiFish](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/BarramundiFish) is supposed to face in the positive z direction/left, which it does after this fix. 

Before fix
<img width="361" height="259" alt="image" src="https://github.com/user-attachments/assets/48a87e36-897f-4db4-b14e-ede925846479" />

After fix
<img width="361" height="217" alt="image" src="https://github.com/user-attachments/assets/64f0b1ea-4c45-432c-b6d6-3f43b36fee73" />



## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [X] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.1 Pro

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.