### PR TITLE
Fix Image ownership semantics

### DIFF
--- a/graphics/include/gz/common/Image.hh
+++ b/graphics/include/gz/common/Image.hh
@@ -122,6 +122,15 @@ namespace gz
       /// \brief Destructor
       public: virtual ~Image();
 
+      /// \brief Move constructor
+      /// \param[in] _other Image to move from
+      public: Image(Image &&_other) noexcept;
+
+      /// \brief Move assignment operator
+      /// \param[in] _other Image to move from
+      /// \return Reference to this image
+      public: Image &operator=(Image &&_other) noexcept;
+
       /// \brief Load an image. Return 0 on success
       /// \param[in] _filename the path to the image file
       /// \return 0 when the operation succeeds to open a file or -1 when fails.
@@ -329,7 +338,7 @@ namespace gz
       }
 
       /// \brief Private data pointer
-      GZ_UTILS_IMPL_PTR(dataPtr)
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
   }
 }

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -15,6 +15,7 @@
  *
  */
 #include <algorithm>
+#include <utility>
 #define STB_IMAGE_IMPLEMENTATION
 #include "STB/stb_image.h"
 
@@ -104,7 +105,7 @@ namespace gz
 
 //////////////////////////////////////////////////
 Image::Image(const std::string &_filename)
-: dataPtr(gz::utils::MakeImpl<Implementation>())
+: dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
   this->dataPtr->bitmap = NULL;
   if (!_filename.empty())
@@ -120,9 +121,33 @@ Image::Image(const std::string &_filename)
 //////////////////////////////////////////////////
 Image::~Image()
 {
-  if (this->dataPtr->bitmap)
+  if (this->dataPtr && this->dataPtr->bitmap)
+  {
     stbi_image_free(this->dataPtr->bitmap);
-  this->dataPtr->bitmap = NULL;
+    this->dataPtr->bitmap = nullptr;
+  }
+}
+
+//////////////////////////////////////////////////
+Image::Image(Image &&_other) noexcept
+: dataPtr(std::move(_other.dataPtr))
+{
+}
+
+//////////////////////////////////////////////////
+Image &Image::operator=(Image &&_other) noexcept
+{
+  if (this == &_other)
+    return *this;
+
+  if (this->dataPtr && this->dataPtr->bitmap)
+  {
+    stbi_image_free(this->dataPtr->bitmap);
+    this->dataPtr->bitmap = nullptr;
+  }
+
+  this->dataPtr = std::move(_other.dataPtr);
+  return *this;
 }
 
 

--- a/graphics/src/Image_TEST.cc
+++ b/graphics/src/Image_TEST.cc
@@ -17,6 +17,8 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -26,6 +28,11 @@
 #include "gz/common/testing/TestPaths.hh"
 
 using namespace gz;
+
+static_assert(!std::is_copy_constructible_v<common::Image>);
+static_assert(!std::is_copy_assignable_v<common::Image>);
+static_assert(std::is_nothrow_move_constructible_v<common::Image>);
+static_assert(std::is_nothrow_move_assignable_v<common::Image>);
 
 class ImageTest : public common::testing::AutoLogFixture { };
 
@@ -99,6 +106,20 @@ TEST_F(ImageTest, ImageConstructorProperties)
 
   ASSERT_TRUE(img.Filename().find("red_blue_colors.png") !=
       std::string::npos);
+}
+
+/////////////////////////////////////////////////
+TEST_F(ImageTest, MoveSemantics)
+{
+  common::Image source(kTestData);
+  CheckImageRGBA(source);
+
+  common::Image constructed(std::move(source));
+  CheckImageRGBA(constructed);
+
+  common::Image assigned(kTestDataGazeboJpeg);
+  assigned = std::move(constructed);
+  CheckImageRGBA(assigned);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- make `Image` use a unique implementation pointer so the bitmap cannot be shallow-copied
- add explicit noexcept move construction and assignment, preserving return-by-value use cases
- release an existing destination bitmap before move assignment
- verify the public type traits and ownership transfer in `Image_TEST`

## Validation
- `git diff --check`
- `bazel test //graphics:Image_TEST` *(cannot build in this local macOS environment because the installed Command Line Tools are missing the libc++ standard headers; the failure occurs while compiling external `tinyxml2` / `fmt`, before gz-common sources)*
- `cmake -S . -B build-codex -DBUILD_TESTING=ON` *(cannot configure locally because `gz-cmake` is not installed)*

Closes #731
