### PR TITLE
Prepare for 6.4.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common6 VERSION 6.3.0)
+project(gz-common6 VERSION 6.4.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,48 @@
 ## Gazebo Common 6.x
 
+### Gazebo Common 6.4.0 (2026-08-24)
+
+1. COLLADA loader updates:
+    * [Pull request #894](https://github.com/gazebosim/gz-common/pull/894)
+    * [Pull request #884](https://github.com/gazebosim/gz-common/pull/884)
+    * [Pull request #855](https://github.com/gazebosim/gz-common/pull/855)
+
+1. Adds mesh Centroid() and fix Volume() for meshes offset from the origin
+    * [Pull request #888](https://github.com/gazebosim/gz-common/pull/888)
+
+1. Merge mesh loader tests with common expectations into MeshManager_TEST
+    * [Pull request #866](https://github.com/gazebosim/gz-common/pull/866)
+
+1. Minor AssimpLoader changes
+    * [Pull request #860](https://github.com/gazebosim/gz-common/pull/860)
+
+1. Change STLLoader to assign name to submesh
+    * [Pull request #852](https://github.com/gazebosim/gz-common/pull/852)
+
+1. Add API for requesting a new mesh from the MeshManager
+    * [Pull request #849](https://github.com/gazebosim/gz-common/pull/849)
+
+1. Improve performance on STL loader (ASCII)
+    * [Pull request #836](https://github.com/gazebosim/gz-common/pull/836)
+
+1. macos CI: use brew trust
+    * [Pull request #828](https://github.com/gazebosim/gz-common/pull/828)
+
+1. Fix SystemPaths_TEST in sandboxed builds
+    * [Pull request #807](https://github.com/gazebosim/gz-common/pull/807)
+
+1. Refactor `RedirectConsoleStream` to use portable C++ stream buffer redirection
+    * [Pull request #809](https://github.com/gazebosim/gz-common/pull/809)
+
+1. graphics: Optimize Texture Processing and Memory in AssimpLoader
+    * [Pull request #781](https://github.com/gazebosim/gz-common/pull/781)
+
+1. av: Fix data races and buffer overflows
+    * [Pull request #773](https://github.com/gazebosim/gz-common/pull/773)
+
+1. Fix `NaN` result in `Animation::Time()` for zero-length animations
+    * [Pull request #769](https://github.com/gazebosim/gz-common/pull/769)
+
 ### Gazebo Common 6.3.0 (2026-01-28)
 
 1. Add functions for clearing FindFile* callbacks

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common6</name>
-  <version>6.3.0</version>
+  <version>6.4.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.4.0 release.

Comparison to 6.3.0: https://github.com/gazebosim/gz-common/compare/gz-common6_6.3.0...gz-common6

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.