### PR TITLE
Prepare for 5.9.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-common5 VERSION 5.8.0)
+project(gz-common5 VERSION 5.9.0)
 set(GZ_COMMON_VER ${PROJECT_VERSION_MAJOR})
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,63 @@
 ## Gazebo Common 5.x
 
+### Gazebo Common 5.9.0 (2026-08-24)
+
+1. COLLADA loader updates:
+    * [Pull request #895](https://github.com/gazebosim/gz-common/pull/895)
+    * [Pull request #885](https://github.com/gazebosim/gz-common/pull/885)
+    * [Pull request #856](https://github.com/gazebosim/gz-common/pull/856)
+
+1. Adds mesh Centroid() and fix Volume() for meshes offset from the origin
+    * [Pull request #889](https://github.com/gazebosim/gz-common/pull/889)
+
+1. Merge mesh loader tests with common expectations into MeshManager_TEST
+    * [Pull request #865](https://github.com/gazebosim/gz-common/pull/865)
+
+1. Minor AssimpLoader changes
+    * [Pull request #859](https://github.com/gazebosim/gz-common/pull/859)
+
+1. Drop Focal, add Noble for gz-common5
+    * [Pull request #864](https://github.com/gazebosim/gz-common/pull/864)
+
+1. Change STLLoader to assign name to submesh
+    * [Pull request #851](https://github.com/gazebosim/gz-common/pull/851)
+
+1. Add API for requesting a new mesh from the MeshManager
+    * [Pull request #848](https://github.com/gazebosim/gz-common/pull/848)
+
+1. Improve performance on STL loader (ASCII)
+    * [Pull request #837](https://github.com/gazebosim/gz-common/pull/837)
+
+1. macos CI: use brew trust
+    * [Pull request #829](https://github.com/gazebosim/gz-common/pull/829)
+
+1. Fix flakiness in PluginSpecialization.AccessTime performance test
+    * [Pull request #820](https://github.com/gazebosim/gz-common/pull/820)
+
+1. Added missing includes
+    * [Pull request #798](https://github.com/gazebosim/gz-common/pull/798)
+
+1. Fix SystemPaths_TEST in sandboxed builds
+    * [Pull request #810](https://github.com/gazebosim/gz-common/pull/810)
+
+1. av:Fix memory leak in video and videoEncoder
+    * [Pull request #788](https://github.com/gazebosim/gz-common/pull/788)
+
+1. graphics: Optimize Texture Processing and Memory in AssimpLoader
+    * [Pull request #782](https://github.com/gazebosim/gz-common/pull/782)
+
+1. Fix ASan ODR violation in INTEGRATION_plugin test
+    * [Pull request #791](https://github.com/gazebosim/gz-common/pull/791)
+
+1. graphics:Fix Image memory leak
+    * [Pull request #789](https://github.com/gazebosim/gz-common/pull/789)
+
+1. av: Fix data races and buffer overflows
+    * [Pull request #774](https://github.com/gazebosim/gz-common/pull/774)
+
+1. Fix `NaN` result in `Animation::Time()` for zero-length animations
+    * [Pull request #770](https://github.com/gazebosim/gz-common/pull/770)
+
 ### Gazebo Common 5.8.0 (2026-01-28)
 
 1. Add functions for clearing FindFile* callbacks

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gz-common5</name>
-  <version>5.8.0</version>
+  <version>5.9.0</version>
   <description>Gazebo Common : AV, Graphics, Events, and much more.</description>
   <maintainer email="natekoenig@gmail.com">Nate Koenig</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
# 🎈 Release

Preparation for 5.9.0 release.

Comparison to 5.8.0: https://github.com/gazebosim/gz-common/compare/gz-common5_5.8.0...gz-common5

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.