### PR TITLE
Prepare for 4.9.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-common4 VERSION 4.8.1)
+project(ignition-common4 VERSION 4.9.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,21 @@
 ## Gazebo Common 4.x
 
+### Gazebo Common 4.9.0 (2026-08-24)
+
+1. COLLADA loader updates:
+    * [Pull request #896](https://github.com/gazebosim/gz-common/pull/896)
+    * [Pull request #886](https://github.com/gazebosim/gz-common/pull/886)
+    * [Pull request #857](https://github.com/gazebosim/gz-common/pull/857)
+
+1. Adds mesh Centroid() and fix Volume() for meshes offset from the origin
+    * [Pull request #890](https://github.com/gazebosim/gz-common/pull/890)
+
+1. Improve performance on STL loader (ASCII)
+    * [Pull request #838](https://github.com/gazebosim/gz-common/pull/838)
+
+1. Fix flakiness in PluginSpecialization.AccessTime performance test
+    * [Pull request #821](https://github.com/gazebosim/gz-common/pull/821)
+
 ### Gazebo Common 4.8.1 (2026-06-09)
 
 1. Added missing includes


### PR DESCRIPTION
# 🎈 Release

Preparation for 4.9.0 release.

Comparison to 4.8.1: https://github.com/gazebosim/gz-common/compare/ignition-common4_4.8.1...ign-common4

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.