### PR TITLE
Do lazy texture loading for non-embedded textures in AssimpLoader

### DIFF
--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -117,14 +117,15 @@ class AssimpLoader::Implementation
   /// \param[in] _texturePath the path where the texture is located
   /// \param[in] _textureName the name of the texture
   /// \param[in] _shouldCache Whether the image should be cached
+  /// \param[in] _loadFullTexture Whether to load the full texture into memory
   /// \return a pair containing the name of the texture and a pointer to the
   /// image data, if the texture was loaded in memory
   public: std::pair<std::string, ImagePtr>
           LoadTexture(const aiScene* _scene,
                       const aiString& _texturePath,
                       const std::string& _textureName,
-                      const bool _shouldCache = true,
-                      const bool _loadFullTexture = true) const;
+                      bool _shouldCache = true,
+                      bool _loadFullTexture = true) const;
 
   /// \brief Function to split a gltf metallicroughness map into
   /// a metalness and roughness map
@@ -847,8 +848,8 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
     const aiScene* _scene,
     const aiString& _texturePath,
     const std::string& _textureName,
-    const bool _shouldCache,
-    const bool _loadFullTexture) const
+    bool _shouldCache,
+    bool _loadFullTexture) const
 {
   std::pair<std::string, ImagePtr> ret;
   std::string textureKey = this->FullTextureKey(_texturePath.C_Str());

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -728,23 +728,6 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
   }
   else
   {
-    // Load external texture from disk
-    if (common::exists(textureKey))
-    {
-      gzdbg << "Loading external texture [" << textureKey << "]" << std::endl;
-      // Textures are uploaded to the GPU as RGBA; decode straight to RGBA in a
-      // single pass to avoid a later channel conversion.
-      ret.second = std::make_shared<Image>();
-      ret.second->Load(textureKey, Image::PixelFormatType::RGBA_INT8);
-      if (_shouldCache)
-      {
-        this->imageCache[textureKey] = ret.second;
-      }
-    }
-    else
-    {
-      gzerr << "External texture [" << textureKey << "] not found" << std::endl;
-    }
     ret.first = ToString(_texturePath);
   }
   return ret;

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -631,14 +631,12 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   {
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
 
-    // Check if the texture is embedded or not
-    auto embeddedTexture = _scene->GetEmbeddedTexture(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Diffuse"),
         true, false);
     // If texture is not embedded, just set the texture
     // image to the path to the parent folder of the texture.
-    if (embeddedTexture)
+    if (texData)
       mat->SetTextureImage(texName, texData);
     else
       mat->SetTextureImage(texName, _path);

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -444,47 +444,50 @@ void AssimpLoader::Implementation::RecursiveCreate(const aiScene* _scene,
     {
       // TODO(luca) merging skeletons here
       auto skeleton = _mesh->MeshSkeleton();
-      // TODO(luca) Append to existing skeleton if multiple submeshes?
-      skeleton->SetNumVertAttached(subMesh.VertexCount());
-      // Now add the bone weights
-      for (unsigned boneIdx = 0; boneIdx < assimpMesh->mNumBones; ++boneIdx)
+      if (skeleton)
       {
-        auto& bone = assimpMesh->mBones[boneIdx];
-        std::string boneNodeName;
-        if (const auto node = bone->mNode)
+        // TODO(luca) Append to existing skeleton if multiple submeshes?
+        skeleton->SetNumVertAttached(subMesh.VertexCount());
+        // Now add the bone weights
+        for (unsigned boneIdx = 0; boneIdx < assimpMesh->mNumBones; ++boneIdx)
         {
-          boneNodeName = this->GetSkeletonNodeName(node, extension);
+          auto& bone = assimpMesh->mBones[boneIdx];
+          std::string boneNodeName;
+          if (const auto node = bone->mNode)
+          {
+            boneNodeName = this->GetSkeletonNodeName(node, extension);
+          }
+          else
+          {
+            boneNodeName = ToString(bone->mName);
+          }
+          // Apply inverse bind transform to the matching node
+          SkeletonNode *skelNode =
+              skeleton->NodeByName(boneNodeName);
+          if (skelNode == nullptr)
+            continue;
+          skelNode->SetInverseBindTransform(
+              this->ConvertTransform(bone->mOffsetMatrix) * _transform.Inverse());
+          for (unsigned weightIdx = 0; weightIdx < bone->mNumWeights; ++weightIdx)
+          {
+            auto vertexWeight = bone->mWeights[weightIdx];
+            skeleton->AddVertNodeWeight(
+                vertexWeight.mVertexId, boneNodeName, vertexWeight.mWeight);
+          }
         }
-        else
+        // Add node assignment to mesh
+        for (unsigned vertexIdx = 0; vertexIdx < subMesh.VertexCount();
+            ++vertexIdx)
         {
-          boneNodeName = ToString(bone->mName);
-        }
-        // Apply inverse bind transform to the matching node
-        SkeletonNode *skelNode =
-            skeleton->NodeByName(boneNodeName);
-        if (skelNode == nullptr)
-          continue;
-        skelNode->SetInverseBindTransform(
-            this->ConvertTransform(bone->mOffsetMatrix) * _transform.Inverse());
-        for (unsigned weightIdx = 0; weightIdx < bone->mNumWeights; ++weightIdx)
-        {
-          auto vertexWeight = bone->mWeights[weightIdx];
-          skeleton->AddVertNodeWeight(
-              vertexWeight.mVertexId, boneNodeName, vertexWeight.mWeight);
-        }
-      }
-      // Add node assignment to mesh
-      for (unsigned vertexIdx = 0; vertexIdx < subMesh.VertexCount();
-          ++vertexIdx)
-      {
-        for (unsigned i = 0; i < skeleton->VertNodeWeightCount(vertexIdx); ++i)
-        {
-          std::pair<std::string, double> nodeWeight =
-            skeleton->VertNodeWeight(vertexIdx, i);
-          SkeletonNode *node =
-              skeleton->NodeByName(nodeWeight.first);
-          subMesh.AddNodeAssignment(vertexIdx,
-                          node->Handle(), nodeWeight.second);
+          for (unsigned i = 0; i < skeleton->VertNodeWeightCount(vertexIdx); ++i)
+          {
+            std::pair<std::string, double> nodeWeight =
+              skeleton->VertNodeWeight(vertexIdx, i);
+            SkeletonNode *node =
+                skeleton->NodeByName(nodeWeight.first);
+            subMesh.AddNodeAssignment(vertexIdx,
+                            node->Handle(), nodeWeight.second);
+          }
         }
       }
     }
@@ -1182,49 +1185,58 @@ Mesh *AssimpLoader::Load(const std::string &_filename)
   this->dataPtr->RecursiveCreate(scene, rootNode, rootTransform, mesh);
   auto rootSkeleton = mesh->MeshSkeleton();
   // Add the animations
-  for (unsigned animIdx = 0; animIdx < scene->mNumAnimations; ++animIdx)
+  if (rootSkeleton)
   {
-    auto& anim = scene->mAnimations[animIdx];
-    auto animName = ToString(anim->mName);
-    if (animName.empty())
+    for (unsigned animIdx = 0; animIdx < scene->mNumAnimations; ++animIdx)
     {
-      animName = "animation" +
-                 std::to_string(rootSkeleton->AnimationCount() + 1);
-    }
-    SkeletonAnimation* skelAnim = new SkeletonAnimation(animName);
-    for (unsigned chanIdx = 0; chanIdx < anim->mNumChannels; ++chanIdx)
-    {
-      auto& animChan = anim->mChannels[chanIdx];
-      auto chanName = ToString(animChan->mNodeName);
-      if (auto animNode = scene->mRootNode->FindNode(animChan->mNodeName))
+      auto& anim = scene->mAnimations[animIdx];
+      auto animName = ToString(anim->mName);
+      if (animName.empty())
       {
-        chanName = this->dataPtr->GetSkeletonNodeName(animNode, extension);
+        animName = "animation" +
+                   std::to_string(rootSkeleton->AnimationCount() + 1);
       }
-      auto numKeys = std::max(
-          animChan->mNumPositionKeys, animChan->mNumRotationKeys);
-      // Position and rotation arrays might be different lengths,
-      // iterate over the maximum of the two, safely access by checking
-      // number of keys
-      for (unsigned keyIdx = 0; keyIdx < numKeys; ++keyIdx)
+      SkeletonAnimation* skelAnim = new SkeletonAnimation(animName);
+      for (unsigned chanIdx = 0; chanIdx < anim->mNumChannels; ++chanIdx)
       {
-        // Note, Scaling keys are not supported right now
-        // Compute the position into a math pose
-        auto& posKey = animChan->mPositionKeys[
-          std::min(keyIdx, animChan->mNumPositionKeys - 1)];
-        auto& quatKey = animChan->mRotationKeys[
-          std::min(keyIdx, animChan->mNumRotationKeys - 1)];
-        math::Vector3d pos(posKey.mValue.x, posKey.mValue.y, posKey.mValue.z);
-        math::Quaterniond quat(quatKey.mValue.w, quatKey.mValue.x,
-            quatKey.mValue.y, quatKey.mValue.z);
-        math::Pose3d pose(pos, quat);
-        // Time is in ms
-        skelAnim->AddKeyFrame(chanName, posKey.mTime / 1000.0, pose);
+        auto& animChan = anim->mChannels[chanIdx];
+        auto chanName = ToString(animChan->mNodeName);
+        if (auto animNode = scene->mRootNode->FindNode(animChan->mNodeName))
+        {
+          chanName = this->dataPtr->GetSkeletonNodeName(animNode, extension);
+        }
+        auto numKeys = std::max(
+            animChan->mNumPositionKeys, animChan->mNumRotationKeys);
+        // Position and rotation arrays might be different lengths,
+        // iterate over the maximum of the two, safely access by checking
+        // number of keys
+        for (unsigned keyIdx = 0; keyIdx < numKeys; ++keyIdx)
+        {
+          // Note, Scaling keys are not supported right now
+          // Compute the position into a math pose
+          auto& posKey = animChan->mPositionKeys[
+            std::min(keyIdx, animChan->mNumPositionKeys - 1)];
+          auto& quatKey = animChan->mRotationKeys[
+            std::min(keyIdx, animChan->mNumRotationKeys - 1)];
+          math::Vector3d pos(posKey.mValue.x, posKey.mValue.y, posKey.mValue.z);
+          math::Quaterniond quat(quatKey.mValue.w, quatKey.mValue.x,
+              quatKey.mValue.y, quatKey.mValue.z);
+          math::Pose3d pose(pos, quat);
+          // Time is in ms
+          skelAnim->AddKeyFrame(chanName, posKey.mTime / 1000.0, pose);
+        }
       }
+      rootSkeleton->AddAnimation(skelAnim);
     }
-    mesh->MeshSkeleton()->AddAnimation(skelAnim);
-  }
 
-  this->dataPtr->ApplyInvBindTransform(mesh->MeshSkeleton());
+    this->dataPtr->ApplyInvBindTransform(rootSkeleton);
+  }
+  else if (scene->mNumAnimations > 0)
+  {
+    gzwarn << "Mesh [" << _filename
+           << "] contains animations but no skeleton was found. "
+           << "Animations will not be loaded." << std::endl;
+  }
 
   return mesh;
 }

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -572,7 +572,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       auto [texName, texData] =
           this->LoadTexture(_scene, texturePath,
                             this->GenerateTextureName(textureKey, "Metalness"));
-      pbr.SetMetalnessMap(texName);
+      pbr.SetMetalnessMap(texName, texData);
     }
     ret = assimpMat->GetTexture(
         aiTextureType_DIFFUSE_ROUGHNESS, 0, &texturePath);
@@ -582,7 +582,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       auto [texName, texData] =
           this->LoadTexture(_scene, texturePath,
                             this->GenerateTextureName(textureKey, "Roughness"));
-      pbr.SetRoughnessMap(texName);
+      pbr.SetRoughnessMap(texName, texData);
     }
   }
 
@@ -605,7 +605,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     // Separate uv set so treat it as a separate texture
     if (uvIdx > 0)
     {
-      pbr.SetLightMap(texName, uvIdx);
+      pbr.SetLightMap(texName, uvIdx, texData);
     }
     // else split the occlusion data from the metallicRoughness texture
     else
@@ -630,7 +630,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
           auto tex = std::make_shared<Image>();
           tex->SetFromData(texRData.data(), texData->Width(), texData->Height(),
               Image::L_INT8);
-          pbr.SetLightMap(texName, uvIdx);
+          pbr.SetLightMap(texName, uvIdx, tex);
         }
       }
     }
@@ -646,7 +646,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Normal"));
     // TODO(luca) different normal map spaces
-    pbr.SetNormalMap(texName, NormalMapSpace::TANGENT);
+    pbr.SetNormalMap(texName, NormalMapSpace::TANGENT, texData);
   }
   ret = assimpMat->GetTexture(aiTextureType_EMISSIVE, 0, &texturePath);
   if (ret == AI_SUCCESS)
@@ -654,7 +654,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Emissive"));
-    pbr.SetEmissiveMap(texName);
+    pbr.SetEmissiveMap(texName, texData);
   }
 
   ret = assimpMat->GetTexture(aiTextureType_SPECULAR, 0, &texturePath);
@@ -728,7 +728,6 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
   }
   else
   {
-    std::cout << "Not embedded: " << ToString(_texturePath) << std::endl;
     ret.first = ToString(_texturePath);
   }
   return ret;

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -480,9 +480,16 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
 
     // Check if the texture is embedded or not
+    auto embeddedTexture = _scene->GetEmbeddedTexture(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Diffuse"));
-    mat->SetTextureImage(texName, texData);
+    // If texture is not embedded, just set the texture
+    // image to the path to the parent folder of the texture.
+    if (embeddedTexture)
+      mat->SetTextureImage(texName, texData);
+    else
+      mat->SetTextureImage(texName, _path);
+
     // Now set the alpha from texture, if enabled, only supported in GLTF
     aiString alphaMode;
     auto paramRet = assimpMat->Get(AI_MATKEY_GLTF_ALPHAMODE, alphaMode);

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -719,20 +719,18 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       this->LoadTexture(_scene, texturePath,
         this->GenerateTextureName(textureKey, "Metalness"),
         true, false);
-      pbr.SetMetalnessMap(texName, texData);
-      std::cout << "aiTextureType_METALNESS" << texName << std::endl;
+      pbr.SetMetalnessMap(textureKey, texData);
     }
     ret = assimpMat->GetTexture(
         aiTextureType_DIFFUSE_ROUGHNESS, 0, &texturePath);
     if (ret == AI_SUCCESS)
     {
-      std::cout << "aiTextureType_DIFFUSE_ROUGHNESS\n";
       std::string textureKey = this->FullTextureKey(texturePath.C_Str());
       auto [texName, texData] =
           this->LoadTexture(_scene, texturePath,
                             this->GenerateTextureName(textureKey, "Roughness"),
                             true, false);
-      pbr.SetRoughnessMap(texName, texData);
+      pbr.SetRoughnessMap(textureKey, texData);
     }
   }
 
@@ -755,7 +753,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     // Separate uv set so treat it as a separate texture
     if (uvIdx > 0)
     {
-      std::cout << "aiTextureType_LIGHTMAP 1: " << texName << std::endl;
       pbr.SetLightMap(texName, uvIdx, texData);
     }
     // else split the occlusion data from the metallicRoughness texture
@@ -782,7 +779,6 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
           tex->SetFromData(texRData.data(), texData->Width(), texData->Height(),
               Image::L_INT8);
           pbr.SetLightMap(texName, uvIdx, tex);
-          std::cout << "aiTextureType_LIGHTMAP 2: " << texName << std::endl;
         }
       }
     }
@@ -799,8 +795,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       _scene, texturePath, this->GenerateTextureName(textureKey, "Normal"),
       true, false);
       // TODO(luca) different normal map spaces
-    pbr.SetNormalMap(texName, NormalMapSpace::TANGENT, texData);
-    std::cout << "aiTextureType_NORMALS OR HEIGHT: " << texName << std::endl;
+    pbr.SetNormalMap(textureKey, NormalMapSpace::TANGENT, texData);
   }
   ret = assimpMat->GetTexture(aiTextureType_EMISSIVE, 0, &texturePath);
   if (ret == AI_SUCCESS)
@@ -809,8 +804,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     auto [texName, texData] = this->LoadTexture(
       _scene, texturePath, this->GenerateTextureName(textureKey, "Emissive"),
       true, false);
-    pbr.SetEmissiveMap(texName, texData);
-    std::cout << "aiTextureType_EMISSIVE: " << texName << std::endl;
+    pbr.SetEmissiveMap(textureKey, texData);
   }
 
   ret = assimpMat->GetTexture(aiTextureType_SPECULAR, 0, &texturePath);
@@ -820,8 +814,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     auto [texName, texData] = this->LoadTexture(
       _scene, texturePath, this->GenerateTextureName(textureKey, "Specular"),
       true, false);
-    pbr.SetSpecularMap(texName);
-    std::cout << "aiTextureType_SPECULAR: " << texName << std::endl;
+    pbr.SetSpecularMap(textureKey);
   }
 
   float value;

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -467,8 +467,10 @@ void AssimpLoader::Implementation::RecursiveCreate(const aiScene* _scene,
           if (skelNode == nullptr)
             continue;
           skelNode->SetInverseBindTransform(
-              this->ConvertTransform(bone->mOffsetMatrix) * _transform.Inverse());
-          for (unsigned weightIdx = 0; weightIdx < bone->mNumWeights; ++weightIdx)
+              this->ConvertTransform(
+                  bone->mOffsetMatrix) * _transform.Inverse());
+          for (unsigned weightIdx = 0; weightIdx < bone->mNumWeights;
+              ++weightIdx)
           {
             auto vertexWeight = bone->mWeights[weightIdx];
             skeleton->AddVertNodeWeight(
@@ -479,7 +481,8 @@ void AssimpLoader::Implementation::RecursiveCreate(const aiScene* _scene,
         for (unsigned vertexIdx = 0; vertexIdx < subMesh.VertexCount();
             ++vertexIdx)
         {
-          for (unsigned i = 0; i < skeleton->VertNodeWeightCount(vertexIdx); ++i)
+          for (unsigned i = 0; i < skeleton->VertNodeWeightCount(vertexIdx);
+              ++i)
           {
             std::pair<std::string, double> nodeWeight =
               skeleton->VertNodeWeight(vertexIdx, i);

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -572,7 +572,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       auto [texName, texData] =
           this->LoadTexture(_scene, texturePath,
                             this->GenerateTextureName(textureKey, "Metalness"));
-      pbr.SetMetalnessMap(texName, texData);
+      pbr.SetMetalnessMap(texName);
     }
     ret = assimpMat->GetTexture(
         aiTextureType_DIFFUSE_ROUGHNESS, 0, &texturePath);
@@ -582,7 +582,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       auto [texName, texData] =
           this->LoadTexture(_scene, texturePath,
                             this->GenerateTextureName(textureKey, "Roughness"));
-      pbr.SetRoughnessMap(texName, texData);
+      pbr.SetRoughnessMap(texName);
     }
   }
 
@@ -605,7 +605,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     // Separate uv set so treat it as a separate texture
     if (uvIdx > 0)
     {
-      pbr.SetLightMap(texName, uvIdx, texData);
+      pbr.SetLightMap(texName, uvIdx);
     }
     // else split the occlusion data from the metallicRoughness texture
     else
@@ -630,7 +630,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
           auto tex = std::make_shared<Image>();
           tex->SetFromData(texRData.data(), texData->Width(), texData->Height(),
               Image::L_INT8);
-          pbr.SetLightMap(texName, uvIdx, tex);
+          pbr.SetLightMap(texName, uvIdx);
         }
       }
     }
@@ -646,7 +646,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Normal"));
     // TODO(luca) different normal map spaces
-    pbr.SetNormalMap(texName, NormalMapSpace::TANGENT, texData);
+    pbr.SetNormalMap(texName, NormalMapSpace::TANGENT);
   }
   ret = assimpMat->GetTexture(aiTextureType_EMISSIVE, 0, &texturePath);
   if (ret == AI_SUCCESS)
@@ -654,7 +654,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
         _scene, texturePath, this->GenerateTextureName(textureKey, "Emissive"));
-    pbr.SetEmissiveMap(texName, texData);
+    pbr.SetEmissiveMap(texName);
   }
 
   ret = assimpMat->GetTexture(aiTextureType_SPECULAR, 0, &texturePath);
@@ -728,6 +728,7 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
   }
   else
   {
+    std::cout << "Not embedded: " << ToString(_texturePath) << std::endl;
     ret.first = ToString(_texturePath);
   }
   return ret;

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -123,8 +123,8 @@ class AssimpLoader::Implementation
           LoadTexture(const aiScene* _scene,
                       const aiString& _texturePath,
                       const std::string& _textureName,
-                      bool _shouldCache = true,
-                      bool _loadFullTexture = true) const;
+                      const bool _shouldCache = true,
+                      const bool _loadFullTexture = true) const;
 
   /// \brief Function to split a gltf metallicroughness map into
   /// a metalness and roughness map
@@ -797,7 +797,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     auto [texName, texData] = this->LoadTexture(
       _scene, texturePath, this->GenerateTextureName(textureKey, "Normal"),
       true, false);
-      // TODO(luca) different normal map spaces
+    // TODO(luca) different normal map spaces
     pbr.SetNormalMap(textureKey, NormalMapSpace::TANGENT, texData);
   }
   ret = assimpMat->GetTexture(aiTextureType_EMISSIVE, 0, &texturePath);
@@ -844,8 +844,8 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
     const aiScene* _scene,
     const aiString& _texturePath,
     const std::string& _textureName,
-    bool _shouldCache,
-    bool _loadFullTexture) const
+    const bool _shouldCache,
+    const bool _loadFullTexture) const
 {
   std::pair<std::string, ImagePtr> ret;
   std::string textureKey = this->FullTextureKey(_texturePath.C_Str());

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -716,18 +716,22 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     {
       std::string textureKey = this->FullTextureKey(texturePath.C_Str());
       auto [texName, texData] =
-          this->LoadTexture(_scene, texturePath,
-                            this->GenerateTextureName(textureKey, "Metalness"));
+      this->LoadTexture(_scene, texturePath,
+        this->GenerateTextureName(textureKey, "Metalness"),
+        true, false);
       pbr.SetMetalnessMap(texName, texData);
+      std::cout << "aiTextureType_METALNESS" << texName << std::endl;
     }
     ret = assimpMat->GetTexture(
         aiTextureType_DIFFUSE_ROUGHNESS, 0, &texturePath);
     if (ret == AI_SUCCESS)
     {
+      std::cout << "aiTextureType_DIFFUSE_ROUGHNESS\n";
       std::string textureKey = this->FullTextureKey(texturePath.C_Str());
       auto [texName, texData] =
           this->LoadTexture(_scene, texturePath,
-                            this->GenerateTextureName(textureKey, "Roughness"));
+                            this->GenerateTextureName(textureKey, "Roughness"),
+                            true, false);
       pbr.SetRoughnessMap(texName, texData);
     }
   }
@@ -751,6 +755,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     // Separate uv set so treat it as a separate texture
     if (uvIdx > 0)
     {
+      std::cout << "aiTextureType_LIGHTMAP 1: " << texName << std::endl;
       pbr.SetLightMap(texName, uvIdx, texData);
     }
     // else split the occlusion data from the metallicRoughness texture
@@ -777,6 +782,7 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
           tex->SetFromData(texRData.data(), texData->Width(), texData->Height(),
               Image::L_INT8);
           pbr.SetLightMap(texName, uvIdx, tex);
+          std::cout << "aiTextureType_LIGHTMAP 2: " << texName << std::endl;
         }
       }
     }
@@ -790,17 +796,21 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   {
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
-        _scene, texturePath, this->GenerateTextureName(textureKey, "Normal"));
-    // TODO(luca) different normal map spaces
+      _scene, texturePath, this->GenerateTextureName(textureKey, "Normal"),
+      true, false);
+      // TODO(luca) different normal map spaces
     pbr.SetNormalMap(texName, NormalMapSpace::TANGENT, texData);
+    std::cout << "aiTextureType_NORMALS OR HEIGHT: " << texName << std::endl;
   }
   ret = assimpMat->GetTexture(aiTextureType_EMISSIVE, 0, &texturePath);
   if (ret == AI_SUCCESS)
   {
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
-        _scene, texturePath, this->GenerateTextureName(textureKey, "Emissive"));
+      _scene, texturePath, this->GenerateTextureName(textureKey, "Emissive"),
+      true, false);
     pbr.SetEmissiveMap(texName, texData);
+    std::cout << "aiTextureType_EMISSIVE: " << texName << std::endl;
   }
 
   ret = assimpMat->GetTexture(aiTextureType_SPECULAR, 0, &texturePath);
@@ -808,8 +818,10 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
   {
     std::string textureKey = this->FullTextureKey(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
-      _scene, texturePath, this->GenerateTextureName(textureKey, "Specular"));
+      _scene, texturePath, this->GenerateTextureName(textureKey, "Specular"),
+      true, false);
     pbr.SetSpecularMap(texName);
+    std::cout << "aiTextureType_SPECULAR: " << texName << std::endl;
   }
 
   float value;

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -723,8 +723,8 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
       std::string textureKey = this->FullTextureKey(texturePath.C_Str());
       auto [texName, texData] =
       this->LoadTexture(_scene, texturePath,
-        this->GenerateTextureName(textureKey, "Metalness"),
-        true, false);
+                        this->GenerateTextureName(textureKey, "Metalness"),
+                        true, false);
       pbr.SetMetalnessMap(textureKey, texData);
     }
     ret = assimpMat->GetTexture(

--- a/graphics/src/AssimpLoader.cc
+++ b/graphics/src/AssimpLoader.cc
@@ -123,7 +123,8 @@ class AssimpLoader::Implementation
           LoadTexture(const aiScene* _scene,
                       const aiString& _texturePath,
                       const std::string& _textureName,
-                      bool _shouldCache = true) const;
+                      bool _shouldCache = true,
+                      bool _loadFullTexture = true) const;
 
   /// \brief Function to split a gltf metallicroughness map into
   /// a metalness and roughness map
@@ -482,7 +483,8 @@ MaterialPtr AssimpLoader::Implementation::CreateMaterial(
     // Check if the texture is embedded or not
     auto embeddedTexture = _scene->GetEmbeddedTexture(texturePath.C_Str());
     auto [texName, texData] = this->LoadTexture(
-        _scene, texturePath, this->GenerateTextureName(textureKey, "Diffuse"));
+        _scene, texturePath, this->GenerateTextureName(textureKey, "Diffuse"),
+        true, false);
     // If texture is not embedded, just set the texture
     // image to the path to the parent folder of the texture.
     if (embeddedTexture)
@@ -690,7 +692,8 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
     const aiScene* _scene,
     const aiString& _texturePath,
     const std::string& _textureName,
-    bool _shouldCache) const
+    bool _shouldCache,
+    bool _loadFullTexture) const
 {
   std::pair<std::string, ImagePtr> ret;
   std::string textureKey = this->FullTextureKey(_texturePath.C_Str());
@@ -729,6 +732,27 @@ std::pair<std::string, ImagePtr> AssimpLoader::Implementation::LoadTexture(
   else
   {
     ret.first = ToString(_texturePath);
+    if (_loadFullTexture)
+    {
+      // Load external texture from disk
+      if (common::exists(textureKey))
+      {
+        gzdbg << "Loading external texture [" << textureKey << "]" << std::endl;
+        // Textures are uploaded to the GPU as RGBA; decode straight to RGBA in
+        // a single pass to avoid a later channel conversion.
+        ret.second = std::make_shared<Image>();
+        ret.second->Load(textureKey, Image::PixelFormatType::RGBA_INT8);
+        if (_shouldCache)
+        {
+          this->imageCache[textureKey] = ret.second;
+        }
+      }
+      else
+      {
+        gzerr << "External texture [" << textureKey << "] not found"
+              << std::endl;
+      }
+    }
   }
   return ret;
 }

--- a/graphics/src/MeshManager_TEST.cc
+++ b/graphics/src/MeshManager_TEST.cc
@@ -1185,11 +1185,11 @@ TEST_F(MeshManager, LoadGlTF2BoxExternalTexture)
 
   const common::MaterialPtr mat = mesh->MaterialByIndex(0u);
   ASSERT_TRUE(mat.get());
-  // Data is now loaded in memory
-  EXPECT_NE(nullptr, mat->TextureData());
+  // External textures are not immediately loaded by AssimpLoader
+  EXPECT_EQ(nullptr, mat->TextureData());
   auto testTextureFile =
     common::testing::TestFile("data/gltf", "PurpleCube_Diffuse.png");
-  EXPECT_EQ("PurpleCube_Diffuse.png", mat->TextureImage());
+  EXPECT_EQ(testTextureFile, mat->TextureImage());
 
   // Test that SpecularMap has data
   auto materialId = mesh->SubMeshByIndex(0).lock()->GetMaterialIndex();

--- a/graphics/src/MeshManager_TEST.cc
+++ b/graphics/src/MeshManager_TEST.cc
@@ -980,9 +980,12 @@ TEST_P(MeshManagerLoad, PBR)
     const common::Pbr *pbr = mat->PbrMaterial();
     EXPECT_DOUBLE_EQ(0, pbr->Roughness());
     EXPECT_DOUBLE_EQ(0, pbr->Metalness());
-    EXPECT_EQ("LightDome_Metalness.png", pbr->MetalnessMap());
-    EXPECT_EQ("LightDome_Roughness.png", pbr->RoughnessMap());
-    EXPECT_EQ("LightDome_Normal.png", pbr->NormalMap());
+    EXPECT_EQ(common::testing::TestFile("data", "LightDome_Metalness.png"),
+        pbr->MetalnessMap());
+    EXPECT_EQ(common::testing::TestFile("data", "LightDome_Roughness.png"),
+        pbr->RoughnessMap());
+    EXPECT_EQ(common::testing::TestFile("data", "LightDome_Normal.png"),
+        pbr->NormalMap());
     mgr->RemoveAll();
   }
 
@@ -1037,10 +1040,13 @@ TEST_P(MeshManagerLoad, PBR)
     else
     {
       EXPECT_DOUBLE_EQ(0.0, pbr->Roughness());
-      EXPECT_EQ("mesh_Rough.png", pbr->RoughnessMap());  // map_Ns
-      EXPECT_EQ("mesh_Metal.png", pbr->MetalnessMap());  // refl
+      EXPECT_EQ(common::testing::TestFile("data", "mesh_Rough.png"),
+          pbr->RoughnessMap());  // map_Ns
+      EXPECT_EQ(common::testing::TestFile("data", "mesh_Metal.png"),
+          pbr->MetalnessMap());  // refl
     }
-    EXPECT_EQ("mesh_Normal.png", pbr->NormalMap());
+    EXPECT_EQ(common::testing::TestFile("data", "mesh_Normal.png"),
+        pbr->NormalMap());
   }
 }
 
@@ -1230,7 +1236,7 @@ TEST_F(MeshManager, LoadGlTF2BoxExternalTexture)
   ASSERT_NE(material, nullptr);
   auto pbr = material->PbrMaterial();
   ASSERT_NE(pbr, nullptr);
-  EXPECT_NE(pbr->SpecularMap(), testTextureFile);
+  EXPECT_EQ(pbr->SpecularMap(), testTextureFile);
 }
 
 /////////////////////////////////////////////////

--- a/graphics/src/OBJLoader.cc
+++ b/graphics/src/OBJLoader.cc
@@ -153,7 +153,8 @@ Mesh *OBJLoader::Load(const std::string &_filename)
             Pbr pbrMat;
             // PBR shoved into standard textures
             if (!m.specular_texname.empty())
-              pbrMat.SetRoughnessMap(m.specular_texname);
+              pbrMat.SetRoughnessMap(
+                  common::joinPaths(path, m.specular_texname));
 
             // check if obj is exported by blender
             // blender obj exporter puts roughness map in specular highlight
@@ -164,26 +165,31 @@ Mesh *OBJLoader::Load(const std::string &_filename)
             // when blender fixes their exporter issue
             if (!m.specular_highlight_texname.empty() && exportedByBlender)
             {
-              pbrMat.SetRoughnessMap(m.specular_highlight_texname);
+              pbrMat.SetRoughnessMap(
+                  common::joinPaths(path, m.specular_highlight_texname));
               if (!m.reflection_texname.empty())
                 pbrMat.SetMetalnessMap(m.reflection_texname);
             }
             else if (!m.reflection_texname.empty())
             {
-              pbrMat.SetEnvironmentMap(m.reflection_texname);
+              pbrMat.SetEnvironmentMap(
+                  common::joinPaths(path, m.reflection_texname));
             }
             if (!m.bump_texname.empty())
-              pbrMat.SetNormalMap(m.bump_texname);
+              pbrMat.SetNormalMap(common::joinPaths(path, m.bump_texname));
 
             // PBR extension - overrides standard materials
             if (!m.roughness_texname.empty())
-              pbrMat.SetRoughnessMap(m.roughness_texname);
+              pbrMat.SetRoughnessMap(
+                  common::joinPaths(path, m.roughness_texname));
             if (!m.metallic_texname.empty())
-              pbrMat.SetMetalnessMap(m.metallic_texname);
+              pbrMat.SetMetalnessMap(
+                common::joinPaths(path, m.metallic_texname));
             if (!m.normal_texname.empty())
-              pbrMat.SetNormalMap(m.normal_texname);
+              pbrMat.SetNormalMap(common::joinPaths(path, m.normal_texname));
             if (!m.emissive_texname.empty())
-              pbrMat.SetEmissiveMap(m.emissive_texname);
+              pbrMat.SetEmissiveMap(
+                  common::joinPaths(path, m.emissive_texname));
 
             pbrMat.SetRoughness(m.roughness);
             pbrMat.SetMetalness(m.metallic);

--- a/graphics/src/OBJLoader.cc
+++ b/graphics/src/OBJLoader.cc
@@ -168,7 +168,8 @@ Mesh *OBJLoader::Load(const std::string &_filename)
               pbrMat.SetRoughnessMap(
                   common::joinPaths(path, m.specular_highlight_texname));
               if (!m.reflection_texname.empty())
-                pbrMat.SetMetalnessMap(m.reflection_texname);
+                pbrMat.SetMetalnessMap(
+                    common::joinPaths(path, m.reflection_texname));
             }
             else if (!m.reflection_texname.empty())
             {
@@ -184,7 +185,7 @@ Mesh *OBJLoader::Load(const std::string &_filename)
                   common::joinPaths(path, m.roughness_texname));
             if (!m.metallic_texname.empty())
               pbrMat.SetMetalnessMap(
-                common::joinPaths(path, m.metallic_texname));
+                  common::joinPaths(path, m.metallic_texname));
             if (!m.normal_texname.empty())
               pbrMat.SetNormalMap(common::joinPaths(path, m.normal_texname));
             if (!m.emissive_texname.empty())


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #839

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

As described in #839, the AssimpLoader currently loads the full texture image in the loader itself, whereas the other loaders just set the texture of the image to the filepath, and let the renderer load the texture image.

This PR makes AssimpLoader match the behaviour of the existing loaders to do "lazy loading" (i.e. just setting the filepath) for non-embedded textures. 

## Visual testing
Tested with collada, obj, gltf with external texture, and glb meshes and textures still appear

<img width="574" height="424" alt="different-meshes-lazy" src="https://github.com/user-attachments/assets/4ae924a3-9718-4475-bd9d-8ebe94e8d13b" />

## Benchmark 
Comparing the loading times for the sydney_regatta.dae (mesh with a lot of textures) file again, I can see that the time taken for loading the mesh drops significantly since the full images are no longer being loaded by AssimpLoader.
```
GZ_MESH_FORCE_ASSIMP=true on main
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
BM_MeshManager/sydney_regatta/1       1031 ms         1000 ms            1
```

```
GZ_MESH_FORCE_ASSIMP=true on this PR
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
BM_MeshManager/sydney_regatta/1       48.9 ms         48.8 ms           13
```

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [X] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [X] Signed all commits for DCO
- [X] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
