### PR TITLE
Suppress graphics warnings for AppleClang

### DIFF
--- a/graphics/src/CMakeLists.txt
+++ b/graphics/src/CMakeLists.txt
@@ -13,8 +13,9 @@ target_link_libraries(${graphics_target}
 
 # CDT does a few float comparisons that cause warnings
 target_compile_options(${graphics_target} PRIVATE
-    $<$<CXX_COMPILER_ID:GNU>:   -Wno-switch-default -Wno-float-equal>   # GCC
-    $<$<CXX_COMPILER_ID:Clang>: -Wno-switch-default -Wno-float-equal>   # Clang
+    $<$<CXX_COMPILER_ID:GNU>:        -Wno-switch-default -Wno-float-equal>   # GCC
+    $<$<CXX_COMPILER_ID:Clang>:      -Wno-switch-default -Wno-float-equal>   # Clang
+    $<$<CXX_COMPILER_ID:AppleClang>: -Wno-switch-default -Wno-float-equal>   # AppleClang
 )
 
 gz_build_tests(


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-cmake/pull/585

## Summary

Since cmake 3.0, the clang compiler on macOS now reports its `CMAKE_CXX_COMPILER_ID` as `AppleClang` instead of `Clang` (see [CMP0025](https://cmake.org/cmake/help/latest/policy/CMP0025.html)), so gz-cmake has had compiler warnings disabled on macOS for a while. The gz-cmake draft PR https://github.com/gazebosim/gz-cmake/pull/585 will reenable these warnings, but we should fix or suppress the warnings in each package before merging that PR.

I identified several compiler warnings in test build of gz-common

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-ci-main-homebrew-arm64&build=106)](https://build.osrfoundation.org/job/gz_common-ci-main-homebrew-arm64/106/) https://build.osrfoundation.org/job/gz_common-ci-main-homebrew-arm64/106/clang/

Several of the warnings are already suppressed for `Clang`, so this extends that logic to `AppleClang` as well.

I used a special `ci_matching_branch/appleclang` branch in order to compile this PR against https://github.com/gazebosim/gz-cmake/pull/585 via a matching branch in https://github.com/osrf/homebrew-simulation/commit/4b40555dc8230ef6e2e14cb23f26d4d82e867df7

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
