### PR TITLE
Annotate WorkerPool_TEST as flaky in bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,10 +93,16 @@ test_sources = glob(
     ],
 )
 
+flaky_test_srcs = [
+    # https://github.com/gazebosim/gz-common/issues/53
+    "src/WorkerPool_TEST.cc",
+]
+
 [cc_test(
     name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
     srcs = [src],
     copts = ["-fexceptions"],
+    flaky = src in flaky_test_srcs,
     deps = [
         ":gz-common",
         "//testing",


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-common/issues/53

## Summary

I noticed the `WorkerPool_TEST` [failed in bazel CI](https://github.com/gazebosim/gz-common/actions/runs/33787113442/job/100754517319?pr=674) for https://github.com/gazebosim/gz-common/pull/674, and it is already documented as flaky in https://github.com/gazebosim/gz-common/issues/53, so I've annotated it as `flaky` in `BUILD.bazel`.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
